### PR TITLE
Drop substring-match log filters that silently dropped legitimate logs

### DIFF
--- a/config/logscope.php
+++ b/config/logscope.php
@@ -98,9 +98,14 @@ return [
     |
     | Configure which logs should be ignored and not captured by LogScope.
     |
-    | 'deprecations' - Ignore PHP deprecation warnings (messages containing
-    |                  "is deprecated"). These typically come from third-party
-    |                  packages and can be noisy.
+    | 'deprecations' - Ignore PHP deprecation warnings. Filters by CHANNEL
+    |                  (default: 'deprecations', Laravel's standard channel
+    |                  for routing E_DEPRECATED). If your app routes
+    |                  deprecations through a differently-named channel,
+    |                  add it to `deprecation_channels`.
+    |
+    | 'deprecation_channels' - Channels treated as PHP-deprecation channels
+    |                  for the filter above. Default ['deprecations'].
     |
     | 'null_channel' - Ignore logs without a channel. These are usually PHP
     |                  errors/warnings captured by Laravel's error handler
@@ -110,6 +115,7 @@ return [
 
     'ignore' => [
         'deprecations' => env('LOGSCOPE_IGNORE_DEPRECATIONS', true),
+        'deprecation_channels' => ['deprecations'],
         'null_channel' => env('LOGSCOPE_IGNORE_NULL_CHANNEL', false),
     ],
 

--- a/src/Logging/LogScopeHandler.php
+++ b/src/Logging/LogScopeHandler.php
@@ -104,20 +104,14 @@ class LogScopeHandler extends AbstractProcessingHandler
 
     /**
      * Check if this is an internal log that should be skipped.
+     *
+     * Only the structured `_logscope_internal` context key triggers the skip.
+     * Substring matches on the message would silently drop legitimate user
+     * logs that mention the package by name.
      */
     protected function isInternalLog(LogRecord $record): bool
     {
-        // Skip logs from our own namespace
-        if (str_contains($record->message, 'LogScope')) {
-            return true;
-        }
-
-        // Check context for LogScope markers
-        if (isset($record->context['_logscope_internal'])) {
-            return true;
-        }
-
-        return false;
+        return isset($record->context['_logscope_internal']);
     }
 
     /**

--- a/src/Services/LogCapture.php
+++ b/src/Services/LogCapture.php
@@ -126,12 +126,15 @@ class LogCapture
     {
         // Check if we should ignore deprecation messages.
         //
-        // Scope to the `deprecations` channel only — Laravel routes PHP
-        // runtime deprecations there (config('logging.deprecations.channel')).
-        // Matching on the message substring "is deprecated" was unsafe: it
-        // silently dropped legitimate business logs that used the same phrase.
-        if (config('logscope.ignore.deprecations', false)) {
-            if ($channel === 'deprecations') {
+        // Scope by CHANNEL — Laravel routes PHP runtime deprecations through
+        // a dedicated channel (default name 'deprecations'). The set of
+        // channels treated as deprecation channels is configurable so apps
+        // that remap the channel name still get the filter. Matching on
+        // the message substring "is deprecated" was unsafe: it silently
+        // dropped legitimate business logs that used the same phrase.
+        if (config('logscope.ignore.deprecations', false) && $channel !== null) {
+            $deprecationChannels = (array) config('logscope.ignore.deprecation_channels', ['deprecations']);
+            if (in_array($channel, $deprecationChannels, true)) {
                 return true;
             }
         }

--- a/src/Services/LogCapture.php
+++ b/src/Services/LogCapture.php
@@ -108,20 +108,15 @@ class LogCapture
 
     /**
      * Check if this is an internal log that should be skipped.
+     *
+     * Only the structured `_logscope_internal` context key triggers the skip.
+     * Substring matches on the message (e.g. checking for "LogScope") are
+     * unsafe — they silently drop legitimate user logs that happen to mention
+     * the package by name (integration error reports, alerts, etc.).
      */
     protected function isInternalLog(MessageLogged $event): bool
     {
-        // Skip logs from our own namespace
-        if (str_contains($event->message, 'LogScope')) {
-            return true;
-        }
-
-        // Check context for LogScope markers
-        if (isset($event->context['_logscope_internal'])) {
-            return true;
-        }
-
-        return false;
+        return isset($event->context['_logscope_internal']);
     }
 
     /**
@@ -129,9 +124,14 @@ class LogCapture
      */
     protected function shouldIgnoreLog(MessageLogged $event, ?string $channel): bool
     {
-        // Check if we should ignore deprecation messages
+        // Check if we should ignore deprecation messages.
+        //
+        // Scope to the `deprecations` channel only — Laravel routes PHP
+        // runtime deprecations there (config('logging.deprecations.channel')).
+        // Matching on the message substring "is deprecated" was unsafe: it
+        // silently dropped legitimate business logs that used the same phrase.
         if (config('logscope.ignore.deprecations', false)) {
-            if (str_contains($event->message, 'is deprecated')) {
+            if ($channel === 'deprecations') {
                 return true;
             }
         }

--- a/tests/Feature/LogFilterFalsePositivesTest.php
+++ b/tests/Feature/LogFilterFalsePositivesTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use LogScope\Logging\ChannelContextProcessor;
+use LogScope\LogScopeServiceProvider;
+use LogScope\Models\LogEntry;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->artisan('migrate', ['--path' => __DIR__.'/../../database/migrations']);
+
+    ChannelContextProcessor::clearLastChannel();
+    LogScopeServiceProvider::resetBufferState();
+    LogEntry::query()->delete();
+
+    config(['logscope.write_mode' => 'sync']);
+});
+
+describe('isInternalLog substring false positive', function () {
+    it('captures user logs that mention "LogScope" by name', function () {
+        Log::error('LogScope client returned 503 — falling back to file driver');
+
+        expect(LogEntry::count())->toBe(1)
+            ->and(LogEntry::first()->message)->toContain('LogScope client returned 503');
+    });
+
+    it('captures user logs about the package even with mixed case', function () {
+        Log::warning('logscope queue depth is at 95% capacity');
+
+        expect(LogEntry::count())->toBe(1);
+    });
+
+    it('still skips logs flagged by the structured _logscope_internal context key', function () {
+        Log::error('any message at all', ['_logscope_internal' => true]);
+
+        expect(LogEntry::count())->toBe(0);
+    });
+});
+
+describe('ignore.deprecations substring false positive', function () {
+    it('captures user logs containing "is deprecated" when filter is on', function () {
+        // Default config has deprecations filter ON — verify it still captures
+        // legitimate business logs that happen to use the phrase.
+        config(['logscope.ignore.deprecations' => true]);
+
+        Log::warning('Account account-42 is deprecated for billing — migrate before 2026-12-31');
+
+        expect(LogEntry::count())->toBe(1);
+    });
+
+    it('still ignores PHP runtime deprecation warnings (channel="deprecations")', function () {
+        config(['logscope.ignore.deprecations' => true]);
+
+        // The post-fix filter ignores deprecations only when the LAST channel
+        // captured by the processor is "deprecations" — Laravel's standard
+        // routing for E_DEPRECATED warnings. Simulate that by setting the
+        // channel directly (the processor would normally do this if the
+        // channel were in config at boot time).
+        $prop = (new ReflectionClass(ChannelContextProcessor::class))
+            ->getProperty('lastChannel');
+        $prop->setAccessible(true);
+        $prop->setValue(null, 'deprecations');
+
+        // Bypass Log::channel() (which would re-resolve the channel and reset
+        // the processor) — fire the event directly with the channel context
+        // already in place.
+        event(new \Illuminate\Log\Events\MessageLogged(
+            'warning',
+            'strpos(): Passing null to parameter #1 is deprecated',
+            []
+        ));
+
+        expect(LogEntry::count())->toBe(0);
+    });
+});

--- a/tests/Feature/LogFilterFalsePositivesTest.php
+++ b/tests/Feature/LogFilterFalsePositivesTest.php
@@ -11,8 +11,9 @@ use LogScope\Models\LogEntry;
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
-    $this->artisan('migrate', ['--path' => __DIR__.'/../../database/migrations']);
-
+    // RefreshDatabase already runs all migrations; package migrations are
+    // registered via loadMigrationsFrom() in LogScopeServiceProvider::boot()
+    // and are picked up automatically. No explicit artisan migrate call needed.
     ChannelContextProcessor::clearLastChannel();
     LogScopeServiceProvider::resetBufferState();
     LogEntry::query()->delete();

--- a/tests/Feature/LogFilterFalsePositivesTest.php
+++ b/tests/Feature/LogFilterFalsePositivesTest.php
@@ -53,22 +53,17 @@ describe('ignore.deprecations substring false positive', function () {
         expect(LogEntry::count())->toBe(1);
     });
 
-    it('still ignores PHP runtime deprecation warnings (channel="deprecations")', function () {
+    it('still ignores PHP runtime deprecation warnings on the default deprecations channel', function () {
         config(['logscope.ignore.deprecations' => true]);
 
         // The post-fix filter ignores deprecations only when the LAST channel
-        // captured by the processor is "deprecations" — Laravel's standard
-        // routing for E_DEPRECATED warnings. Simulate that by setting the
-        // channel directly (the processor would normally do this if the
-        // channel were in config at boot time).
+        // captured by the processor is in the configured deprecation_channels
+        // list (default: ['deprecations']).
         $prop = (new ReflectionClass(ChannelContextProcessor::class))
             ->getProperty('lastChannel');
         $prop->setAccessible(true);
         $prop->setValue(null, 'deprecations');
 
-        // Bypass Log::channel() (which would re-resolve the channel and reset
-        // the processor) — fire the event directly with the channel context
-        // already in place.
         event(new \Illuminate\Log\Events\MessageLogged(
             'warning',
             'strpos(): Passing null to parameter #1 is deprecated',
@@ -76,5 +71,46 @@ describe('ignore.deprecations substring false positive', function () {
         ));
 
         expect(LogEntry::count())->toBe(0);
+    });
+
+    it('honors a custom deprecation_channels list for apps that remap the channel name', function () {
+        config([
+            'logscope.ignore.deprecations' => true,
+            'logscope.ignore.deprecation_channels' => ['php-deprecations', 'legacy-warnings'],
+        ]);
+
+        $prop = (new ReflectionClass(ChannelContextProcessor::class))
+            ->getProperty('lastChannel');
+        $prop->setAccessible(true);
+        $prop->setValue(null, 'php-deprecations');
+
+        event(new \Illuminate\Log\Events\MessageLogged('warning', 'a deprecation', []));
+
+        // The default 'deprecations' name is no longer in the list, but our
+        // custom name is — log should be ignored.
+        expect(LogEntry::count())->toBe(0);
+    });
+
+    it('does not ignore logs from channels NOT in the deprecation_channels list', function () {
+        config([
+            'logscope.ignore.deprecations' => true,
+            'logscope.ignore.deprecation_channels' => ['deprecations'],
+        ]);
+
+        $prop = (new ReflectionClass(ChannelContextProcessor::class))
+            ->getProperty('lastChannel');
+        $prop->setAccessible(true);
+        $prop->setValue(null, 'application');
+
+        // 'application' isn't in the deprecation_channels list — the log must
+        // be captured even though the message mentions deprecation (the old
+        // substring filter would have dropped it).
+        event(new \Illuminate\Log\Events\MessageLogged(
+            'warning',
+            'feature flag x is deprecated',
+            []
+        ));
+
+        expect(LogEntry::count())->toBe(1);
     });
 });


### PR DESCRIPTION
## Summary

Two filters used `str_contains` on the log message and silently dropped real user logs:

- **`isInternalLog`** dropped any log containing the substring `LogScope`. A user log like `Log::error('LogScope client returned 503 — falling back to file driver')` vanished with no debug trail.
- **`ignore.deprecations`** (default `true`) dropped any log containing `is deprecated`. A legitimate business log like `Log::warning('Account 42 is deprecated for billing')` vanished.

## Fix

- `isInternalLog` now only skips logs with the structured `_logscope_internal` context key (existing signal, was AND'd with the substring match).
- `ignore.deprecations` now scopes by **channel name** — only logs on a configured deprecation channel are dropped. Default: `['deprecations']` (Laravel's standard channel for routing PHP `E_DEPRECATED`). Configurable via `logscope.ignore.deprecation_channels` for apps that remap the channel name.

## ⚠️ Upgrading note (behavior change)

The deprecations filter is now **channel-scoped**, not message-scoped. Most users on default Laravel configs are unaffected — `LOG_DEPRECATIONS_CHANNEL` controls where deprecations go, but Laravel always uses the literal channel name `'deprecations'` at the source. So if your stack has `LOG_DEPRECATIONS_CHANNEL=null` or `=stack`, the default config still filters those out correctly.

You might see new entries appear after this lands if:

- Your app routes deprecations through a custom-named channel (e.g. you wrap `E_DEPRECATED` and emit on a channel called `php-warnings`). Add it to the list:
  ```php
  // config/logscope.php
  'ignore' => [
      'deprecations' => true,
      'deprecation_channels' => ['deprecations', 'php-warnings'],
      ...
  ]
  ```
- Your code was emitting business logs that contained the literal phrase `is deprecated` and you were unintentionally relying on the old substring filter to hide them. Those will now be captured. To silence specific log lines, use the `_logscope_internal` context key:
  ```php
  Log::info('foo is deprecated', ['_logscope_internal' => true]);
  ```
- You can also disable the filter entirely: `LOGSCOPE_IGNORE_DEPRECATIONS=false`.

The `isInternalLog` change is **not** breaking — it only narrows what gets dropped (structured marker only, no substring). Anything previously captured is still captured.

## Test plan

`tests/Feature/LogFilterFalsePositivesTest.php` (7 tests, 8 assertions):

- [x] User log mentioning "LogScope" by name → captured
- [x] User log with mixed-case "logscope" → captured
- [x] Structured `_logscope_internal` key → still skipped
- [x] User log containing "is deprecated" → captured (filter on, default channel list)
- [x] PHP runtime deprecation on `deprecations` channel → still ignored
- [x] Custom `deprecation_channels` list → matches custom channel names
- [x] Channel NOT in list → not ignored even when message matches

Verified:
- [x] Full suite: 153 passed, 400 assertions
- [x] `vendor/bin/pint --dirty` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)