### PR TITLE
Register MessageLogged listener in register(), not boot()

### DIFF
--- a/src/LogScopeServiceProvider.php
+++ b/src/LogScopeServiceProvider.php
@@ -44,6 +44,13 @@ class LogScopeServiceProvider extends ServiceProvider
         // provider's boot() (or any earlier-running boot phase) are captured.
         // If the listener were registered in our own boot(), any provider
         // that boots before us would have its boot-time logs silently dropped.
+        //
+        // Caveat: logs fired during another provider's register() (the phase
+        // we are in right now) ARE captured by the listener, but the channel
+        // name will be null. The Monolog channel processor that records the
+        // channel name is installed in the booting() callback above, which
+        // fires later. Logs from boot() onwards have correct channel
+        // attribution.
         $this->registerLogCapture();
     }
 

--- a/src/LogScopeServiceProvider.php
+++ b/src/LogScopeServiceProvider.php
@@ -38,6 +38,13 @@ class LogScopeServiceProvider extends ServiceProvider
         $this->app->booting(function () {
             $this->registerChannelProcessor();
         });
+
+        // Attach the MessageLogged listener as early as possible — in
+        // register() rather than boot() — so logs emitted during another
+        // provider's boot() (or any earlier-running boot phase) are captured.
+        // If the listener were registered in our own boot(), any provider
+        // that boots before us would have its boot-time logs silently dropped.
+        $this->registerLogCapture();
     }
 
     /**
@@ -109,7 +116,6 @@ class LogScopeServiceProvider extends ServiceProvider
         $this->registerViews();
         $this->registerMigrations();
         $this->registerMiddleware();
-        $this->registerLogCapture();
     }
 
     /**

--- a/tests/EagerProvider/EarlyListenerRegistrationTest.php
+++ b/tests/EagerProvider/EarlyListenerRegistrationTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use LogScope\Services\LogBuffer;
+
+it('captures logs fired in another provider boot() that runs before LogScope boot()', function () {
+    // EagerLoggingProvider is registered BEFORE LogScopeServiceProvider in
+    // EagerProviderTestCase, so its boot() runs first in the boot phase.
+    // For LogScope to hear that log, the MessageLogged listener must be
+    // registered during the register phase (before any boot runs).
+    //
+    // We inspect the LogBuffer directly rather than the DB because the
+    // package's migrations haven't run during boot — what we care about is
+    // that the listener heard the event, not that it persisted to disk.
+    $messages = array_map(
+        fn ($entry) => $entry['message'] ?? null,
+        LogBuffer::getBuffer()
+    );
+
+    expect($messages)->toContain('eager-provider-boot-log');
+});

--- a/tests/EagerProvider/EarlyListenerRegistrationTest.php
+++ b/tests/EagerProvider/EarlyListenerRegistrationTest.php
@@ -13,6 +13,11 @@ it('captures logs fired in another provider boot() that runs before LogScope boo
     // We inspect the LogBuffer directly rather than the DB because the
     // package's migrations haven't run during boot — what we care about is
     // that the listener heard the event, not that it persisted to disk.
+    //
+    // No LogBuffer::reset() needed: each Pest test gets a fresh framework
+    // boot, so the buffer starts empty and contains only what was fired
+    // during this test's boot phase. If more tests are added to this folder
+    // and they share state across cases, add a beforeEach() with reset().
     $messages = array_map(
         fn ($entry) => $entry['message'] ?? null,
         LogBuffer::getBuffer()

--- a/tests/EagerProviderTestCase.php
+++ b/tests/EagerProviderTestCase.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LogScope\Tests;
+
+use LogScope\LogScopeServiceProvider;
+use LogScope\Tests\Fixtures\EagerLoggingProvider;
+
+/**
+ * Test case for verifying behavior when another provider boots before
+ * LogScope. EagerLoggingProvider is registered FIRST so its boot() runs
+ * before LogScope's boot() — the only way LogScope can capture its log
+ * is to register its MessageLogged listener during register(), not boot().
+ */
+abstract class EagerProviderTestCase extends TestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [
+            EagerLoggingProvider::class,
+            LogScopeServiceProvider::class,
+        ];
+    }
+}

--- a/tests/Fixtures/EagerLoggingProvider.php
+++ b/tests/Fixtures/EagerLoggingProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LogScope\Tests\Fixtures;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Test fixture: a service provider that emits a log in its boot() method.
+ *
+ * When this provider is registered BEFORE LogScopeServiceProvider in the
+ * provider array, its boot() runs before LogScope's boot(). For the log to
+ * be captured, LogScope must register its MessageLogged listener in
+ * register() (which runs in the register phase, before any boot phase),
+ * not in boot().
+ */
+class EagerLoggingProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        Log::error('eager-provider-boot-log');
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,6 +11,8 @@
 |
 */
 
+use LogScope\Tests\EagerProviderTestCase;
 use LogScope\Tests\TestCase;
 
 pest()->extend(TestCase::class)->in('Feature', 'Unit');
+pest()->extend(EagerProviderTestCase::class)->in('EagerProvider');


### PR DESCRIPTION
## Summary

The `MessageLogged` listener was attached in `LogScopeServiceProvider::boot()`, which meant any log emitted during an earlier-booting provider's `boot()` was silently dropped.

Service providers boot in registration order. LogScope sits mid-list (~position 16 in a typical Laravel 12 app — verified locally). Framework providers (positions 0–15) and any user provider registered before LogScope that logs during boot lost the entry with no debug trail.

## Fix

Move `registerLogCapture()` from `boot()` into `register()`. The listener now attaches during the register phase, before any `boot()` runs. Service registration already wires up `LogCapture` and its dependencies, so nothing else moves.

## Test plan

New test in `tests/EagerProvider/`:

- `EagerLoggingProvider` — fires `Log::error('eager-provider-boot-log')` in its `boot()`
- `EagerProviderTestCase` — registers `EagerLoggingProvider` BEFORE `LogScopeServiceProvider` in the providers array, so its `boot()` runs first
- `EarlyListenerRegistrationTest` — inspects `LogBuffer` (not DB, since migrations haven't run at boot time) for the eager log

The test:
- [x] Fails on the old code (listener in `boot()`) — log dropped, buffer empty
- [x] Passes after the move (listener in `register()`) — log captured to buffer
- [x] Full suite: 146 passed, 392 assertions
- [x] Pint clean

## Why a separate test folder

The new test uses a custom `EagerProviderTestCase` to reorder the providers. The default `tests/Pest.php` binds `Feature/` and `Unit/` to `LogScope\Tests\TestCase`, so the new TestCase needs its own folder. Added one line to `Pest.php` to bind `EagerProvider/` to `EagerProviderTestCase`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)