### PR TITLE
Add re-entrant WriteGuard to prevent MessageLogged recursion during writes

### DIFF
--- a/src/Jobs/WriteLogEntry.php
+++ b/src/Jobs/WriteLogEntry.php
@@ -10,6 +10,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use LogScope\Models\LogEntry;
+use LogScope\Services\WriteGuard;
 
 class WriteLogEntry implements ShouldQueue
 {
@@ -30,9 +31,16 @@ class WriteLogEntry implements ShouldQueue
 
     /**
      * Execute the job.
+     *
+     * Wrapped in WriteGuard so a re-entrant log fired during the insert
+     * (LogEntry observer, query listener that logs, etc.) is skipped by
+     * the listener instead of recursing back into another job dispatch.
+     * The dispatch-time guard in LogWriter::write only covers the parent
+     * request — by the time the worker runs this job, the guard has been
+     * cleared (or we're in a different process entirely).
      */
     public function handle(): void
     {
-        LogEntry::createEntry($this->data);
+        WriteGuard::during(fn () => LogEntry::createEntry($this->data));
     }
 }

--- a/src/LogScopeServiceProvider.php
+++ b/src/LogScopeServiceProvider.php
@@ -213,9 +213,14 @@ class LogScopeServiceProvider extends ServiceProvider
 
     /**
      * Reset the buffer state (used for testing).
+     *
+     * Also resets WriteGuard's depth counter — if a previous test crashed
+     * mid-`during()` block, the static depth could be left > 0 and silently
+     * skip captures in every subsequent test.
      */
     public static function resetBufferState(): void
     {
         LogBuffer::reset();
+        \LogScope\Services\WriteGuard::reset();
     }
 }

--- a/src/Logging/LogScopeHandler.php
+++ b/src/Logging/LogScopeHandler.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Context;
 use LogScope\Concerns\ResolvesExceptionSource;
 use LogScope\LogScope;
 use LogScope\Models\LogEntry;
+use LogScope\Services\WriteGuard;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Level;
 use Monolog\LogRecord;
@@ -42,6 +43,11 @@ class LogScopeHandler extends AbstractProcessingHandler
      */
     protected function write(LogRecord $record): void
     {
+        // Re-entrant guard: skip logs emitted DURING our own write path.
+        if (WriteGuard::isWriting()) {
+            return;
+        }
+
         // Prevent infinite loops - don't log our own operations
         if ($this->isInternalLog($record)) {
             return;
@@ -50,6 +56,15 @@ class LogScopeHandler extends AbstractProcessingHandler
         // Mark that we're handling this log (prevents duplicate capture by listener)
         static::$handledCurrentLog = true;
 
+        WriteGuard::during(fn () => $this->writeRecord($record));
+    }
+
+    /**
+     * Persist the captured record. Wrapped by write() inside WriteGuard
+     * so a nested log fired during the insert is skipped.
+     */
+    protected function writeRecord(LogRecord $record): void
+    {
         try {
             $this->ensureInitialized();
 

--- a/src/Services/LogBuffer.php
+++ b/src/Services/LogBuffer.php
@@ -120,20 +120,25 @@ class LogBuffer implements LogBufferInterface
         $logsToFlush = self::$buffer;
         self::$buffer = [];
 
-        try {
-            $limits = self::$cachedLimits ?: config('logscope.limits', []);
-            $rows = array_map(fn ($data) => LogEntry::prepareData($data, $limits), $logsToFlush);
+        // Guard against re-entry: an observer or query listener that fires
+        // a log during the bulk insert would otherwise be re-captured by
+        // LogCapture and added back to the buffer or written sync.
+        WriteGuard::during(function () use ($logsToFlush) {
+            try {
+                $limits = self::$cachedLimits ?: config('logscope.limits', []);
+                $rows = array_map(fn ($data) => LogEntry::prepareData($data, $limits), $logsToFlush);
 
-            foreach (array_chunk($rows, 500) as $chunk) {
-                try {
-                    LogEntry::insert(self::normalizeChunk($chunk));
-                } catch (Throwable $e) {
-                    error_log('LogScope: Failed to flush log buffer chunk: ['.get_class($e).'] '.$e->getMessage());
+                foreach (array_chunk($rows, 500) as $chunk) {
+                    try {
+                        LogEntry::insert(self::normalizeChunk($chunk));
+                    } catch (Throwable $e) {
+                        error_log('LogScope: Failed to flush log buffer chunk: ['.get_class($e).'] '.$e->getMessage());
+                    }
                 }
+            } catch (Throwable $e) {
+                error_log('LogScope: Failed to flush log buffer: ['.get_class($e).'] '.$e->getMessage());
             }
-        } catch (Throwable $e) {
-            error_log('LogScope: Failed to flush log buffer: ['.get_class($e).'] '.$e->getMessage());
-        }
+        });
     }
 
     /**

--- a/src/Services/LogBuffer.php
+++ b/src/Services/LogBuffer.php
@@ -123,22 +123,32 @@ class LogBuffer implements LogBufferInterface
         // Guard against re-entry: an observer or query listener that fires
         // a log during the bulk insert would otherwise be re-captured by
         // LogCapture and added back to the buffer or written sync.
-        WriteGuard::during(function () use ($logsToFlush) {
-            try {
-                $limits = self::$cachedLimits ?: config('logscope.limits', []);
-                $rows = array_map(fn ($data) => LogEntry::prepareData($data, $limits), $logsToFlush);
+        WriteGuard::during(fn () => self::performFlush($logsToFlush));
+    }
 
-                foreach (array_chunk($rows, 500) as $chunk) {
-                    try {
-                        LogEntry::insert(self::normalizeChunk($chunk));
-                    } catch (Throwable $e) {
-                        error_log('LogScope: Failed to flush log buffer chunk: ['.get_class($e).'] '.$e->getMessage());
-                    }
+    /**
+     * Bulk-insert the given rows in chunks of 500, with per-chunk error
+     * isolation so one bad chunk doesn't lose the rest. Called only from
+     * inside flushStatic's WriteGuard frame.
+     *
+     * @param  array<int, array<string, mixed>>  $logsToFlush
+     */
+    protected static function performFlush(array $logsToFlush): void
+    {
+        try {
+            $limits = self::$cachedLimits ?: config('logscope.limits', []);
+            $rows = array_map(fn ($data) => LogEntry::prepareData($data, $limits), $logsToFlush);
+
+            foreach (array_chunk($rows, 500) as $chunk) {
+                try {
+                    LogEntry::insert(self::normalizeChunk($chunk));
+                } catch (Throwable $e) {
+                    error_log('LogScope: Failed to flush log buffer chunk: ['.get_class($e).'] '.$e->getMessage());
                 }
-            } catch (Throwable $e) {
-                error_log('LogScope: Failed to flush log buffer: ['.get_class($e).'] '.$e->getMessage());
             }
-        });
+        } catch (Throwable $e) {
+            error_log('LogScope: Failed to flush log buffer: ['.get_class($e).'] '.$e->getMessage());
+        }
     }
 
     /**

--- a/src/Services/LogCapture.php
+++ b/src/Services/LogCapture.php
@@ -43,6 +43,13 @@ class LogCapture
      */
     protected function handleLogEvent(MessageLogged $event): void
     {
+        // Re-entrant guard: a write in progress may itself emit a log
+        // (observer on log_entries, query listener with Log::debug, etc.).
+        // Skip those — capturing them would recurse on every insert.
+        if (WriteGuard::isWriting()) {
+            return;
+        }
+
         // Prevent infinite loops - don't log our own operations
         if ($this->isInternalLog($event)) {
             return;

--- a/src/Services/LogWriter.php
+++ b/src/Services/LogWriter.php
@@ -20,17 +20,23 @@ class LogWriter implements LogWriterInterface
 
     /**
      * Write a log entry based on the configured write mode.
+     *
+     * Wraps the write in WriteGuard so that any nested log emitted
+     * during the write (observer-driven, query listener, etc.) is
+     * skipped by LogCapture/LogScopeHandler instead of recursing.
      */
     public function write(array $data): void
     {
         $mode = config('logscope.write_mode', 'batch');
 
-        match ($mode) {
-            'sync' => $this->writeSync($data),
-            'queue' => $this->writeQueue($data),
-            'batch' => $this->writeBatch($data),
-            default => $this->writeSync($data),
-        };
+        WriteGuard::during(function () use ($mode, $data) {
+            match ($mode) {
+                'sync' => $this->writeSync($data),
+                'queue' => $this->writeQueue($data),
+                'batch' => $this->writeBatch($data),
+                default => $this->writeSync($data),
+            };
+        });
     }
 
     /**

--- a/src/Services/WriteGuard.php
+++ b/src/Services/WriteGuard.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LogScope\Services;
+
+/**
+ * Re-entrant guard that prevents the MessageLogged listener (and the
+ * channel handler) from re-capturing logs that fire DURING LogScope's
+ * own write path. Without this, a user observer on log_entries that
+ * itself logs, or a query listener that logs each query, would cause
+ * the listener to recurse on every insert.
+ *
+ * Implemented as a counter so nested writes still un-guard correctly
+ * when the outermost frame finishes.
+ */
+class WriteGuard
+{
+    private static int $depth = 0;
+
+    public static function isWriting(): bool
+    {
+        return self::$depth > 0;
+    }
+
+    /**
+     * Run the given callback inside the guard. Logs fired from anywhere
+     * in the call tree of $write are skipped by the listener/handler.
+     *
+     * @template T
+     *
+     * @param  callable(): T  $write
+     * @return T
+     */
+    public static function during(callable $write): mixed
+    {
+        self::$depth++;
+        try {
+            return $write();
+        } finally {
+            self::$depth--;
+        }
+    }
+
+    /**
+     * Reset the depth counter. Used only by tests after an unhandled
+     * exception inside `during()` could otherwise leave the depth > 0.
+     */
+    public static function reset(): void
+    {
+        self::$depth = 0;
+    }
+}

--- a/tests/Feature/ReentrantWriteGuardTest.php
+++ b/tests/Feature/ReentrantWriteGuardTest.php
@@ -3,23 +3,31 @@
 declare(strict_types=1);
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use LogScope\Logging\ChannelContextProcessor;
 use LogScope\LogScopeServiceProvider;
 use LogScope\Models\LogEntry;
+use LogScope\Services\WriteGuard;
 
 uses(RefreshDatabase::class);
 
 beforeEach(function () {
     ChannelContextProcessor::clearLastChannel();
     LogScopeServiceProvider::resetBufferState();
+    WriteGuard::reset();
     LogEntry::query()->delete();
 
     config(['logscope.write_mode' => 'sync']);
 });
 
 afterEach(function () {
-    // Drop any observers we wired up for the test.
+    // Test isolation: drop observers wired up by this test class so they
+    // don't leak to other tests. This wipes ALL listeners on LogEntry,
+    // including any the framework may have added (currently none — the
+    // model uses HasUlids/HasFactory/Prunable but none register listeners).
+    // If future Laravel versions add framework listeners we need to keep,
+    // switch to a more surgical removal.
     LogEntry::flushEventListeners();
 });
 
@@ -53,4 +61,67 @@ it('clears the guard after the write so subsequent unrelated logs are captured',
     Log::error('second');
 
     expect(LogEntry::count())->toBe(2);
+});
+
+it('captures a follow-up log even when a re-entrant write happened just before', function () {
+    // Locks in the contract: re-entrancy guard state (WriteGuard::$depth and
+    // LogScopeHandler::$handledCurrentLog) must NOT leak into the next log.
+    //
+    // Trace: user log #1 → observer fires inner log → guard skips inner →
+    //        user log #2 must still land.
+    //
+    // If a future refactor reorders the listener checks (e.g. moves
+    // didHandleCurrentLog before the WriteGuard check), the handledCurrentLog
+    // flag could be consumed by the inner listener and leak past log #1,
+    // causing log #2 to be silently dropped. This test catches that.
+    LogEntry::created(function () {
+        // Fire exactly one re-entrant log (no cap needed; the guard prevents recursion).
+        Log::warning('side-effect');
+    });
+
+    Log::error('user log #1');
+
+    // Drop observer so the follow-up log doesn't trigger another side-effect.
+    LogEntry::flushEventListeners();
+
+    Log::error('user log #2');
+
+    expect(LogEntry::count())->toBe(2)
+        ->and(LogEntry::pluck('message')->all())->toEqualCanonicalizing(['user log #1', 'user log #2']);
+});
+
+it('drops re-entrant query-listener logs in batch mode at flush time', function () {
+    // Same recursion scenario, but with batch mode and a DB query listener
+    // (Eloquent's bulk INSERT bypasses model events, but DB::listen still
+    // fires for the underlying query). The guard must protect this path too.
+    config(['logscope.write_mode' => 'batch']);
+
+    $queryListenerFireCount = 0;
+    DB::listen(function (\Illuminate\Database\Events\QueryExecuted $event) use (&$queryListenerFireCount) {
+        // Only count log_entries inserts so other queries (begin/commit/etc.)
+        // don't pollute the assertion.
+        if (! str_contains($event->sql, 'log_entries')) {
+            return;
+        }
+        $queryListenerFireCount++;
+        if ($queryListenerFireCount > 4) {
+            return;
+        }
+        Log::warning('batch-side-effect-'.$queryListenerFireCount);
+    });
+
+    Log::error('user log');
+    LogScopeServiceProvider::flushLogBufferStatic();
+
+    // The query listener fires for the bulk INSERT. The Log::warning it
+    // emits would be re-captured into the buffer without the guard,
+    // triggering another flush → another query → another listener call.
+    // With the guard, the warning is dropped at the listener level.
+    expect(LogEntry::count())->toBe(1)
+        ->and(LogEntry::first()->message)->toBe('user log');
+
+    // The listener fires at least once for our INSERT. If the guard were
+    // missing, it would fire many more times (each side-effect log creates
+    // another buffer add → another flush → another query).
+    expect($queryListenerFireCount)->toBeGreaterThan(0)->toBeLessThan(5);
 });

--- a/tests/Feature/ReentrantWriteGuardTest.php
+++ b/tests/Feature/ReentrantWriteGuardTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use LogScope\Logging\ChannelContextProcessor;
+use LogScope\LogScopeServiceProvider;
+use LogScope\Models\LogEntry;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    ChannelContextProcessor::clearLastChannel();
+    LogScopeServiceProvider::resetBufferState();
+    LogEntry::query()->delete();
+
+    config(['logscope.write_mode' => 'sync']);
+});
+
+afterEach(function () {
+    // Drop any observers we wired up for the test.
+    LogEntry::flushEventListeners();
+});
+
+it('does not re-capture logs fired by an observer during the write itself', function () {
+    // Hard cap so a regression doesn't actually run forever.
+    $observerFireCount = 0;
+
+    LogEntry::created(function () use (&$observerFireCount) {
+        $observerFireCount++;
+        if ($observerFireCount > 4) {
+            return;
+        }
+        // This Log::warning is fired DURING LogScope's write of the user log.
+        // Without a re-entrant guard, the listener captures it → triggers
+        // another insert → observer fires again → recursion.
+        Log::warning('observer-side-effect-'.$observerFireCount);
+    });
+
+    Log::error('user log');
+
+    // With the guard: only the user log lands. The observer's warning fires
+    // but the listener returns early (we're inside a write), so no second
+    // insert happens.
+    expect(LogEntry::count())->toBe(1)
+        ->and(LogEntry::first()->message)->toBe('user log')
+        ->and($observerFireCount)->toBe(1);
+});
+
+it('clears the guard after the write so subsequent unrelated logs are captured', function () {
+    Log::error('first');
+    Log::error('second');
+
+    expect(LogEntry::count())->toBe(2);
+});


### PR DESCRIPTION
## Summary

When LogScope writes a log entry, the INSERT can trigger downstream events that themselves emit logs:

- A `LogEntry` observer that calls `Log::*`
- A user's `DB::listen` that logs each query via `Log::debug`
- An Eloquent event subscriber that logs

Each fires `MessageLogged`, which the listener was happily re-capturing — leading to runaway entry counts or, in the worst case, infinite recursion.

## Fix

Add `LogScope\Services\WriteGuard` — a simple counter-based static guard.

- `LogWriter::write`, `LogBuffer::flushStatic`, and `LogScopeHandler::write` run their inserts inside `WriteGuard::during(...)`.
- `LogCapture::handleLogEvent` and `LogScopeHandler::write` check `WriteGuard::isWriting()` at entry and skip the event if the depth is > 0.
- The counter (not a bool) lets nested writes un-guard correctly when the outermost frame finishes.

## Test plan

New `tests/Feature/ReentrantWriteGuardTest.php`:

- [x] **Without guard:** a `LogEntry::created` observer that calls `Log::warning` produces 5+ entries from a single `Log::error` (the test caps the observer at 4 fires to avoid actual infinite loop)
- [x] **With guard:** 1 entry — observer's warning fires once but the listener returns early because we're inside a write
- [x] Guard is cleared after the write — subsequent unrelated logs are still captured

Verified:
- Test fails on master, passes after the fix
- Full suite: 148 passed, 396 assertions
- Pint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)