### PR TITLE
prependMiddleware so trace_id is set before any other middleware

### DIFF
--- a/src/LogScopeServiceProvider.php
+++ b/src/LogScopeServiceProvider.php
@@ -122,12 +122,17 @@ class LogScopeServiceProvider extends ServiceProvider
 
     /**
      * Register the request context middleware.
+     *
+     * Prepended (not pushed) so CaptureRequestContext runs FIRST in the
+     * global middleware stack. If an earlier middleware were to throw,
+     * the resulting log entry would have no trace_id/ip_address/url —
+     * making it harder to correlate with the failing request.
      */
     protected function registerMiddleware(): void
     {
         if (config('logscope.middleware.enabled', true)) {
             $kernel = $this->app->make(Kernel::class);
-            $kernel->pushMiddleware(CaptureRequestContext::class);
+            $kernel->prependMiddleware(CaptureRequestContext::class);
         }
     }
 

--- a/src/LogScopeServiceProvider.php
+++ b/src/LogScopeServiceProvider.php
@@ -127,13 +127,31 @@ class LogScopeServiceProvider extends ServiceProvider
      * global middleware stack. If an earlier middleware were to throw,
      * the resulting log entry would have no trace_id/ip_address/url —
      * making it harder to correlate with the failing request.
+     *
+     * Defensive: in apps that don't bind the HTTP kernel (e.g. console-only
+     * applications, or custom kernels that don't extend Foundation's), the
+     * make() call may throw or the resolved object may not implement
+     * prependMiddleware. Skip in those cases rather than crashing during
+     * service-provider boot.
      */
     protected function registerMiddleware(): void
     {
-        if (config('logscope.middleware.enabled', true)) {
-            $kernel = $this->app->make(Kernel::class);
-            $kernel->prependMiddleware(CaptureRequestContext::class);
+        if (! config('logscope.middleware.enabled', true)) {
+            return;
         }
+
+        try {
+            $kernel = $this->app->make(Kernel::class);
+        } catch (\Throwable) {
+            // No HTTP kernel bound — running in a non-HTTP context.
+            return;
+        }
+
+        if (! method_exists($kernel, 'prependMiddleware')) {
+            return;
+        }
+
+        $kernel->prependMiddleware(CaptureRequestContext::class);
     }
 
     /**

--- a/tests/Feature/MiddlewareOrderingTest.php
+++ b/tests/Feature/MiddlewareOrderingTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Http\Kernel;
+use LogScope\Http\Middleware\CaptureRequestContext;
+
+it('registers CaptureRequestContext at the front of the global middleware stack', function () {
+    $kernel = $this->app->make(Kernel::class);
+
+    // Reach into the kernel's middleware list — Laravel doesn't expose
+    // ordering via a public API, but the order is what we actually care
+    // about: CaptureRequestContext must run before any other global
+    // middleware so trace_id/ip_address/url are present in Context if
+    // an earlier middleware throws.
+    $reflection = new ReflectionProperty($kernel, 'middleware');
+    $reflection->setAccessible(true);
+    $middleware = $reflection->getValue($kernel);
+
+    $position = array_search(CaptureRequestContext::class, $middleware, true);
+
+    expect($position)->toBe(0);
+});

--- a/tests/Feature/MiddlewareOrderingTest.php
+++ b/tests/Feature/MiddlewareOrderingTest.php
@@ -4,20 +4,76 @@ declare(strict_types=1);
 
 use Illuminate\Contracts\Http\Kernel;
 use LogScope\Http\Middleware\CaptureRequestContext;
+use LogScope\Tests\Fixtures\StubGlobalMiddleware;
 
-it('registers CaptureRequestContext at the front of the global middleware stack', function () {
-    $kernel = $this->app->make(Kernel::class);
-
-    // Reach into the kernel's middleware list — Laravel doesn't expose
-    // ordering via a public API, but the order is what we actually care
-    // about: CaptureRequestContext must run before any other global
-    // middleware so trace_id/ip_address/url are present in Context if
-    // an earlier middleware throws.
+/**
+ * Read the kernel's global middleware list via reflection. Laravel doesn't
+ * expose middleware order publicly, but the order is the property under test.
+ *
+ * @return list<class-string>
+ */
+function readMiddlewareStack(Kernel $kernel): array
+{
     $reflection = new ReflectionProperty($kernel, 'middleware');
     $reflection->setAccessible(true);
-    $middleware = $reflection->getValue($kernel);
 
-    $position = array_search(CaptureRequestContext::class, $middleware, true);
+    return $reflection->getValue($kernel);
+}
 
-    expect($position)->toBe(0);
+it('registers CaptureRequestContext at the front of the global middleware stack', function () {
+    $middleware = readMiddlewareStack($this->app->make(Kernel::class));
+
+    // Currently LogScope is the only prependMiddleware caller in the test
+    // setup, so it lands at index 0. Other PRs/packages that also prepend
+    // would compete — see the relative-ordering test below for the more
+    // robust contract.
+    expect(array_search(CaptureRequestContext::class, $middleware, true))->toBe(0);
+});
+
+it('runs before middleware that another package pushes after LogScope booted', function () {
+    $kernel = $this->app->make(Kernel::class);
+
+    // Simulate another package adding a global middleware AFTER LogScope's
+    // service provider booted. CaptureRequestContext must remain ahead of it.
+    $kernel->pushMiddleware(StubGlobalMiddleware::class);
+
+    $middleware = readMiddlewareStack($kernel);
+    $captureIdx = array_search(CaptureRequestContext::class, $middleware, true);
+    $stubIdx = array_search(StubGlobalMiddleware::class, $middleware, true);
+
+    expect($captureIdx)->not->toBeFalse()
+        ->and($stubIdx)->not->toBeFalse()
+        ->and($captureIdx)->toBeLessThan($stubIdx);
+});
+
+it('does not crash when the HTTP kernel is unavailable', function () {
+    // Drop the HTTP kernel binding so make() throws — simulating console-only
+    // or custom-kernel apps where no HTTP kernel is bound. registerMiddleware
+    // should swallow the resolution failure instead of crashing service-provider
+    // boot.
+    $this->app->offsetUnset(Kernel::class);
+
+    $provider = new \LogScope\LogScopeServiceProvider($this->app);
+
+    // Use reflection to invoke the protected registerMiddleware directly.
+    $method = (new ReflectionClass($provider))->getMethod('registerMiddleware');
+    $method->setAccessible(true);
+
+    expect(fn () => $method->invoke($provider))->not->toThrow(\Throwable::class);
+});
+
+it('does not crash when the resolved kernel lacks prependMiddleware', function () {
+    // Bind a stub kernel that doesn't implement prependMiddleware — emulates
+    // a custom kernel that doesn't extend Foundation's HTTP kernel.
+    $this->app->bind(Kernel::class, fn () => new class
+    {
+        // intentionally empty — no prependMiddleware/pushMiddleware
+    });
+
+    $provider = new \LogScope\LogScopeServiceProvider($this->app);
+
+    $method = (new ReflectionClass($provider))->getMethod('registerMiddleware');
+    $method->setAccessible(true);
+
+    expect(fn () => $method->invoke($provider))->not->toThrow(\Throwable::class);
 });

--- a/tests/Fixtures/StubGlobalMiddleware.php
+++ b/tests/Fixtures/StubGlobalMiddleware.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LogScope\Tests\Fixtures;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Stub global middleware used by MiddlewareOrderingTest to verify that
+ * CaptureRequestContext is positioned BEFORE other middleware in the
+ * kernel's stack — even ones registered after LogScope booted.
+ */
+class StubGlobalMiddleware
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        return $next($request);
+    }
+}


### PR DESCRIPTION
## Summary

`CaptureRequestContext` was pushed to the END of the global middleware stack via `pushMiddleware`. If any earlier middleware threw — CORS, Sanctum, custom auth, rate limiting — the resulting log entry would lack `trace_id`, `ip_address`, `http_method`, and `url`, making it harder to correlate with the failing request.

## Fix

Switch `pushMiddleware` → `prependMiddleware`. The middleware now runs first; the request context is set before any other middleware can fail.

Also adds defensive guards so the registration doesn't crash in non-HTTP contexts (console-only apps, custom kernels that don't extend Foundation's).

## ⚠️ Behavior change note

If you previously relied on logs from earlier middleware (CORS, auth) **not** having `trace_id` set — for example, treating null `trace_id` as a "pre-LogScope" marker for early-pipeline logs — those logs will now have one. Most users won't notice. If you have downstream tooling that filters on this distinction, adjust accordingly or set `LOGSCOPE_MIDDLEWARE_ENABLED=false` to opt out entirely.

If another package in your app also calls `prependMiddleware`, the LAST provider to boot wins position 0. Provider boot order is normally stable, but worth noting if you see intermittent ordering issues.

## Test plan

`tests/Feature/MiddlewareOrderingTest.php`:

- [x] **Position 0**: `CaptureRequestContext` is at index 0 of the global middleware stack (sanity check; documents the assumption that LogScope is the only `prependMiddleware` caller in the test setup)
- [x] **Relative ordering**: a stub middleware pushed AFTER LogScope booted lands later in the stack — `CaptureRequestContext` index < stub index. More robust contract that survives other packages also using `prependMiddleware`.
- [x] **Console kernel safety**: with `Kernel::class` binding dropped, `registerMiddleware` doesn't throw
- [x] **Custom kernel safety**: with a stub kernel that lacks `prependMiddleware`, `registerMiddleware` doesn't throw

Verified:
- [x] Full suite: 150 passed, 398 assertions
- [x] `vendor/bin/pint --dirty` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)