### PR TITLE
Fix channel-attribution leak across Log::build() and Octane requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ Visit `/logscope` in your browser. That's it!
 
 ## What's New
 
+### v1.5.5 — Correct channel attribution for `Log::build()` and Octane
+
+The Monolog channel processor stored the last log's channel in static state. Logs that bypassed the processor (`Log::build()` at runtime, or any log on a channel without the processor installed) inherited whatever was left over from a prior log — wrong attribution. In long-running workers (**Laravel Octane**), the static state survived across requests, so a `Log::build()` log in request N+1 could get tagged with the channel from the last log of request N.
+
+LogScope now uses an `$isFresh` flag set by every processor invocation. The new `consumeLastChannel()` returns the channel only when a processor invocation has happened since the last consume, and clears state in one operation. The listener consumes at the very top of its handler so even early-return paths (`isInternalLog`, `didHandleCurrentLog`, `WriteGuard`, ignored logs) leave clean state.
+
+For Octane users specifically, LogScope also registers a listener on `Laravel\Octane\Events\RequestReceived` that clears the channel slot at every request boundary — defense in depth against orphaned state from rare edge cases (Monolog handler exceptions, etc.). The listener only registers when Octane is actually installed.
+
+**Backwards compatibility:** the existing `ChannelContextProcessor::getLastChannel()` returns the raw value (its original semantics); it's now `@deprecated` (removed in 2.0) in favor of `consumeLastChannel()`. Existing test helpers that call `getLastChannel()` continue to work unchanged.
+
+---
+
 ### v1.5.4 — Correct source location for argument-validation errors
 
 When you call `new SomeClass()` with the wrong number or type of arguments, PHP throws an `ArgumentCountError` (or `TypeError` for type mismatches). For these errors PHP's `$e->getFile()`/`$e->getLine()` point at the **callee's declaration** (the constructor's signature), not the **caller** (where `new` was actually written). Previously this meant the `source` column in the log list would show e.g. `app/Services/UserService.php:11` (the constructor) instead of `app/Http/Controllers/UserController.php:42` (the broken `new`) — making it look like the bug was somewhere it wasn't.

--- a/src/LogScopeServiceProvider.php
+++ b/src/LogScopeServiceProvider.php
@@ -38,6 +38,14 @@ class LogScopeServiceProvider extends ServiceProvider
         $this->app->booting(function () {
             $this->registerChannelProcessor();
         });
+
+        // In long-running workers (Octane), static state survives across
+        // requests. Reset ChannelContextProcessor's slot at each Octane
+        // request boundary so a Log::build() log in request N+1 can never
+        // inherit a stale channel from request N. Only registers when
+        // Octane is actually installed — guards against pulling Octane
+        // as a hard dependency.
+        $this->registerOctaneStateReset();
     }
 
     /**
@@ -129,6 +137,32 @@ class LogScopeServiceProvider extends ServiceProvider
             $kernel = $this->app->make(Kernel::class);
             $kernel->pushMiddleware(CaptureRequestContext::class);
         }
+    }
+
+    /**
+     * Reset static channel state at Octane request boundaries.
+     *
+     * Octane keeps the worker process alive across requests. The Monolog
+     * channel processor stores the last channel name in static state.
+     * Without this listener, a Log::build() log in request N+1 could
+     * inherit the channel of request N's last log if a Monolog handler
+     * threw (or any other rare path that orphaned `$isFresh=true`).
+     *
+     * Only registers if Laravel\Octane\Events\RequestReceived exists —
+     * Octane is an optional peer, not a hard dependency.
+     */
+    protected function registerOctaneStateReset(): void
+    {
+        if (! class_exists(\Laravel\Octane\Events\RequestReceived::class)) {
+            return;
+        }
+
+        $this->app['events']->listen(
+            \Laravel\Octane\Events\RequestReceived::class,
+            function (): void {
+                \LogScope\Logging\ChannelContextProcessor::clearLastChannel();
+            }
+        );
     }
 
     /**

--- a/src/Logging/ChannelContextProcessor.php
+++ b/src/Logging/ChannelContextProcessor.php
@@ -25,6 +25,16 @@ class ChannelContextProcessor implements ProcessorInterface
     protected static ?string $lastChannel = null;
 
     /**
+     * Whether `$lastChannel` was set by a processor invocation that has
+     * not yet been consumed by the listener. Used to distinguish "the
+     * processor for THIS log just ran" from "stale state from a previous
+     * log whose listener returned early or didn't run". Without this
+     * flag, a log fired through Log::build() (which has no processor)
+     * would inherit the previous log's channel from the static state.
+     */
+    protected static bool $isFresh = false;
+
+    /**
      * The Laravel channel name this processor is registered for.
      */
     protected string $channel;
@@ -38,16 +48,38 @@ class ChannelContextProcessor implements ProcessorInterface
     {
         // Store the Laravel channel name for the MessageLogged listener
         static::$lastChannel = $this->channel;
+        static::$isFresh = true;
 
         return $record;
     }
 
     /**
-     * Get the last captured channel name.
+     * Consume the channel set by the most recent processor invocation.
+     *
+     * Returns the channel only if a processor invocation has happened
+     * since the last consume. Always clears state so the next log
+     * either gets its own fresh value (processor fires) or `null`
+     * (no processor, e.g. Log::build()).
+     */
+    public static function consumeLastChannel(): ?string
+    {
+        $channel = static::$isFresh ? static::$lastChannel : null;
+        static::$lastChannel = null;
+        static::$isFresh = false;
+
+        return $channel;
+    }
+
+    /**
+     * Get the last captured channel name without consuming it.
+     *
+     * @deprecated since 1.5.5 — prefer consumeLastChannel(), which clears
+     * state in one operation and prevents stale-channel leaks. Kept for
+     * test helpers and backwards compatibility.
      */
     public static function getLastChannel(): ?string
     {
-        return static::$lastChannel;
+        return static::$isFresh ? static::$lastChannel : null;
     }
 
     /**
@@ -56,5 +88,6 @@ class ChannelContextProcessor implements ProcessorInterface
     public static function clearLastChannel(): void
     {
         static::$lastChannel = null;
+        static::$isFresh = false;
     }
 }

--- a/src/Logging/ChannelContextProcessor.php
+++ b/src/Logging/ChannelContextProcessor.php
@@ -71,15 +71,21 @@ class ChannelContextProcessor implements ProcessorInterface
     }
 
     /**
-     * Get the last captured channel name without consuming it.
+     * Get the raw last-captured channel name, ignoring freshness.
      *
-     * @deprecated since 1.5.5 — prefer consumeLastChannel(), which clears
-     * state in one operation and prevents stale-channel leaks. Kept for
-     * test helpers and backwards compatibility.
+     * Returns whatever is currently stored in the static slot, even if
+     * it's stale (set by a prior log whose listener returned early or
+     * never ran). This was the original semantics; the listener no
+     * longer uses this method — it's kept for inspection in tests and
+     * for callers who explicitly want the raw value.
+     *
+     * @deprecated since 1.5.5, removed in 2.0 — prefer consumeLastChannel(),
+     * which clears state in one operation and prevents stale-channel leaks.
+     * New code should NOT depend on the raw value.
      */
     public static function getLastChannel(): ?string
     {
-        return static::$isFresh ? static::$lastChannel : null;
+        return static::$lastChannel;
     }
 
     /**

--- a/src/Services/LogCapture.php
+++ b/src/Services/LogCapture.php
@@ -43,6 +43,15 @@ class LogCapture
      */
     protected function handleLogEvent(MessageLogged $event): void
     {
+        // Consume the channel set by the most recent processor invocation,
+        // BEFORE any early return. consumeLastChannel() returns null unless
+        // a processor invocation happened since the previous consume — so a
+        // Log::build() log (no processor) gets null, and a log from a
+        // configured channel gets that channel. This also prevents stale
+        // state from leaking across requests in long-running workers
+        // (Octane), where static state survives between requests.
+        $channel = ChannelContextProcessor::consumeLastChannel();
+
         // Prevent infinite loops - don't log our own operations
         if ($this->isInternalLog($event)) {
             return;
@@ -53,10 +62,6 @@ class LogCapture
         if (LogScopeHandler::didHandleCurrentLog()) {
             return;
         }
-
-        // Get channel and reset for next log (prevents sticky channel on Log::build())
-        $channel = ChannelContextProcessor::getLastChannel();
-        ChannelContextProcessor::clearLastChannel();
 
         if ($this->shouldIgnoreLog($event, $channel)) {
             return;

--- a/tests/Feature/ChannelStateLeakTest.php
+++ b/tests/Feature/ChannelStateLeakTest.php
@@ -36,3 +36,48 @@ it('does not attribute a stale channel to a fresh log fired without a channel pr
     expect($entry)->not->toBeNull()
         ->and($entry->channel)->toBeNull();
 });
+
+it('consumeLastChannel returns the channel on first call and null on the second', function () {
+    // Locks in the read+clear contract: a single processor invocation
+    // produces exactly one consumable channel value. A second consume
+    // (or any consume after a non-processor log) returns null.
+    $processor = new ChannelContextProcessor('single');
+    $processor(new \Monolog\LogRecord(
+        new \DateTimeImmutable,
+        'app',
+        \Monolog\Level::Error,
+        'msg',
+        []
+    ));
+
+    expect(ChannelContextProcessor::consumeLastChannel())->toBe('single')
+        ->and(ChannelContextProcessor::consumeLastChannel())->toBeNull();
+});
+
+it('getLastChannel returns the raw value regardless of freshness (deprecated path)', function () {
+    // Backwards-compat contract: getLastChannel keeps its original
+    // semantics — return whatever's in the static slot, even if stale.
+    // This is what existing unit tests rely on; the listener uses
+    // consumeLastChannel instead.
+    $channelProp = (new ReflectionClass(ChannelContextProcessor::class))->getProperty('lastChannel');
+    $channelProp->setAccessible(true);
+    $channelProp->setValue(null, 'stale-value');
+
+    // isFresh is false (we set lastChannel directly without a processor invocation).
+    expect(ChannelContextProcessor::getLastChannel())->toBe('stale-value');
+
+    // After a consume (which sets isFresh=false and clears lastChannel),
+    // the raw getter returns null.
+    ChannelContextProcessor::consumeLastChannel();
+    expect(ChannelContextProcessor::getLastChannel())->toBeNull();
+});
+
+it('registers an Octane RequestReceived listener when Octane is installed', function () {
+    // Skip if Octane isn't installed — the listener registration is
+    // gated on the class existing.
+    if (! class_exists(\Laravel\Octane\Events\RequestReceived::class)) {
+        $this->markTestSkipped('Laravel Octane is not installed in the test environment.');
+    }
+
+    expect($this->app['events']->hasListeners(\Laravel\Octane\Events\RequestReceived::class))->toBeTrue();
+});

--- a/tests/Feature/ChannelStateLeakTest.php
+++ b/tests/Feature/ChannelStateLeakTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use LogScope\Logging\ChannelContextProcessor;
+use LogScope\LogScopeServiceProvider;
+use LogScope\Models\LogEntry;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    ChannelContextProcessor::clearLastChannel();
+    LogScopeServiceProvider::resetBufferState();
+    LogEntry::query()->delete();
+
+    config(['logscope.write_mode' => 'sync']);
+});
+
+it('does not attribute a stale channel to a fresh log fired without a channel processor', function () {
+    // Simulate the leak: lastChannel was left set by a previous log whose
+    // listener-handling returned early (didHandleCurrentLog / isInternalLog
+    // / WriteGuard early-return). Now a NEW log fires through Log::build()
+    // (no channel processor for it). Without the fix, the listener reads
+    // the stale lastChannel and attributes it to the wrong log.
+    $channelProp = (new ReflectionClass(ChannelContextProcessor::class))->getProperty('lastChannel');
+    $channelProp->setAccessible(true);
+    $channelProp->setValue(null, 'single');
+
+    // Dispatch a MessageLogged directly — bypassing Laravel's logger lets
+    // us simulate a runtime channel that has no processor installed.
+    event(new \Illuminate\Log\Events\MessageLogged('error', 'fresh-log', []));
+
+    $entry = LogEntry::where('message', 'fresh-log')->first();
+
+    expect($entry)->not->toBeNull()
+        ->and($entry->channel)->toBeNull();
+});


### PR DESCRIPTION
## Summary

`ChannelContextProcessor` stored the last log's channel in static state. Logs that bypassed the processor (`Log::build()` at runtime, or any log on a channel without the processor installed) inherited whatever `$lastChannel` was left over from a prior log — wrong attribution.

In long-running workers (**Octane**), the static state survived across requests. A `Log::build()` log in request N+1 could be tagged with the channel from the last log of request N.

## Fix

Add an `$isFresh` flag set by every processor invocation. New `consumeLastChannel()` returns the channel only when a processor invocation has happened since the last consume, and clears state in one operation. The listener consumes at the very top of `handleLogEvent` so even early-return paths (`isInternalLog`, `didHandleCurrentLog`, `WriteGuard`, `shouldIgnoreLog`) leave clean state.

For Octane users specifically, also register a listener on `Laravel\Octane\Events\RequestReceived` that clears the channel slot at every request boundary. Defense in depth against orphaned state from rare edge cases (e.g., a Monolog handler throwing after the processor ran but before `MessageLogged` fired). Only registers when Octane is actually installed.

## Backwards compatibility

`ChannelContextProcessor::getLastChannel()` keeps its original "return raw `$lastChannel`" semantics — it's now `@deprecated since 1.5.5, removed in 2.0` in favor of `consumeLastChannel()`. Existing test helpers and any callers that used the raw getter continue to work unchanged. New code should use `consumeLastChannel()`.

## Test plan

`tests/Feature/ChannelStateLeakTest.php`:

- [x] **Stale-channel leak**: Set `lastChannel='single'` via reflection, dispatch a fresh `MessageLogged` simulating a `Log::build()` log → captured entry has `channel=null` (not the stale value)
- [x] **`consumeLastChannel` contract**: First call after a processor invocation returns the channel; second call returns null (read+clear semantics)
- [x] **`getLastChannel` backwards-compat**: Returns raw value regardless of freshness (preserves original semantics)
- [x] **Octane registration**: Verifies the `RequestReceived` listener is registered when Octane is installed (skipped when not)

Existing tests:
- [x] `LogBuildTest` (8 tests) — verifies the live `Log::channel()` → `Log::build()` flow
- [x] `ChannelContextProcessorTest`, `AddChannelToContextTest` — unchanged, still pass with the restored `getLastChannel` behavior

Verified:
- [x] Full suite: 149 passed, 1 skipped (Octane test, env doesn't have Octane), 398 assertions
- [x] `vendor/bin/pint --dirty` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)