### PR TITLE
Register flush callbacks eagerly + Octane RequestTerminated listener

### DIFF
--- a/src/LogScopeServiceProvider.php
+++ b/src/LogScopeServiceProvider.php
@@ -60,6 +60,20 @@ class LogScopeServiceProvider extends ServiceProvider
         // Octane is actually installed — guards against pulling Octane
         // as a hard dependency.
         $this->registerOctaneStateReset();
+
+        // Register our buffer-flush callback as early as possible so we're
+        // ahead of most user-provider terminate callbacks in the chain.
+        // Laravel's Application::terminate() runs callbacks in registration
+        // order with NO try/catch around each — if a later-registered
+        // callback throws, our flush would still run; but if a callback
+        // registered before ours throws, we'd be skipped. Registering in
+        // register() (instead of lazily on first add()) puts us as early
+        // in the user-provider phase as possible.
+        //
+        // For Octane specifically, also wire RequestTerminated as an
+        // independent flush trigger that survives even when Laravel's
+        // terminate callback chain is broken by an earlier throw.
+        $this->registerEagerFlushCallbacks();
     }
 
     /**
@@ -199,6 +213,47 @@ class LogScopeServiceProvider extends ServiceProvider
                 \LogScope\Logging\ChannelContextProcessor::clearLastChannel();
             }
         );
+    }
+
+    /**
+     * Register flush callbacks as early as possible.
+     *
+     * - app->terminating(): runs at end of every Laravel request lifecycle.
+     *   Registered eagerly here (not lazily on first log) so we're as early
+     *   in the callback chain as we can be — minimizes the chance an
+     *   earlier-registered callback throws and skips us.
+     * - register_shutdown_function(): backup for CLI/HTTP scenarios where
+     *   the terminate chain didn't reach us. Doesn't help in Octane (only
+     *   fires on worker death).
+     * - Octane RequestTerminated: independent flush trigger that survives
+     *   even if Laravel's terminate callback chain is broken. Octane is an
+     *   optional peer — only registers if installed.
+     */
+    protected function registerEagerFlushCallbacks(): void
+    {
+        // Internal try/catch wraps our own flush so an exception inside it
+        // can't propagate out and break OTHER terminate callbacks downstream.
+        $flushSafely = static function (): void {
+            try {
+                LogBuffer::flushStatic();
+            } catch (\Throwable $e) {
+                error_log('LogScope: Failed to flush buffer at terminate: ['.get_class($e).'] '.$e->getMessage());
+            }
+        };
+
+        $this->app->terminating($flushSafely);
+
+        if (! LogBuffer::shutdownFunctionRegistered()) {
+            register_shutdown_function($flushSafely);
+            LogBuffer::markShutdownFunctionRegistered();
+        }
+
+        if (class_exists(\Laravel\Octane\Events\RequestTerminated::class)) {
+            $this->app['events']->listen(
+                \Laravel\Octane\Events\RequestTerminated::class,
+                $flushSafely
+            );
+        }
     }
 
     /**

--- a/src/LogScopeServiceProvider.php
+++ b/src/LogScopeServiceProvider.php
@@ -228,11 +228,29 @@ class LogScopeServiceProvider extends ServiceProvider
      * - Octane RequestTerminated: independent flush trigger that survives
      *   even if Laravel's terminate callback chain is broken. Octane is an
      *   optional peer — only registers if installed.
+     *
+     * Note on cost: we register unconditionally regardless of write_mode.
+     * In sync/queue modes the buffer is always empty, so flushStatic
+     * early-returns — the per-request cost is one closure call returning
+     * `if (empty($buffer)) return;`. Negligible. Gating on write_mode at
+     * register time would miss runtime config changes (`config([...])`)
+     * and add a footgun for marginal benefit.
+     *
+     * Note on Octane double-flush: in Octane, a request fires BOTH
+     * Application::terminate() (running our `terminating` callback) AND
+     * Octane's RequestTerminated event (running our second listener).
+     * Step 2 is intentionally redundant — the buffer is already drained
+     * by step 1, so the second call is a no-op. The redundancy gives us
+     * a recovery path if the terminate chain is broken by an earlier
+     * throwing callback (the original bug this fix addresses).
      */
     protected function registerEagerFlushCallbacks(): void
     {
         // Internal try/catch wraps our own flush so an exception inside it
         // can't propagate out and break OTHER terminate callbacks downstream.
+        // Exceptions surface via error_log only — tests asserting flush
+        // success should inspect error_log content (see WriteFailureLogger
+        // test pattern) rather than expecting the exception to bubble.
         $flushSafely = static function (): void {
             try {
                 LogBuffer::flushStatic();

--- a/src/Services/LogBuffer.php
+++ b/src/Services/LogBuffer.php
@@ -28,12 +28,10 @@ class LogBuffer implements LogBufferInterface
     protected static array $cachedLimits = [];
 
     /**
-     * Whether terminating callback is registered.
-     */
-    protected static bool $terminatingRegistered = false;
-
-    /**
-     * Whether shutdown function is registered.
+     * Whether the PHP shutdown function has been registered for this
+     * process. Stays true once set so re-registering the service provider
+     * (e.g. in test suites that re-instantiate the app) doesn't stack
+     * multiple shutdown functions calling our flush.
      */
     protected static bool $shutdownRegistered = false;
 
@@ -153,12 +151,19 @@ class LogBuffer implements LogBufferInterface
 
     /**
      * Reset the buffer state (used for testing).
+     *
+     * NOTE: clearing $shutdownRegistered means a subsequent service-provider
+     * register() call WILL register a second register_shutdown_function for
+     * this process. PHP shutdown handlers stack — both will fire at exit.
+     * Both call the same flushSafely() closure, so the second is a no-op
+     * (buffer already drained), but the duplicate registration is a small
+     * test-time leak. Acceptable because resetBufferState() is only called
+     * between tests, and the process exits soon after the suite finishes.
      */
     public static function reset(): void
     {
         self::$buffer = [];
         self::$cachedLimits = [];
-        self::$terminatingRegistered = false;
         self::$shutdownRegistered = false;
     }
 

--- a/src/Services/LogBuffer.php
+++ b/src/Services/LogBuffer.php
@@ -50,33 +50,25 @@ class LogBuffer implements LogBufferInterface
         self::$cachedLimits = config('logscope.limits', []);
 
         self::$buffer[] = $data;
-
-        $this->registerCallbacks();
     }
 
     /**
-     * Register terminating and shutdown callbacks if not already registered.
+     * @internal — called by LogScopeServiceProvider to coordinate eager
+     * shutdown-function registration so it happens at most once per
+     * process even when the provider registers multiple times (e.g. in
+     * test suites that re-instantiate the app).
      */
-    protected function registerCallbacks(): void
+    public static function shutdownFunctionRegistered(): bool
     {
-        // Register terminating callback once (for normal Laravel lifecycle)
-        if (! self::$terminatingRegistered) {
-            self::$terminatingRegistered = true;
+        return self::$shutdownRegistered;
+    }
 
-            $this->app->terminating(function () {
-                $this->flush();
-            });
-        }
-
-        // Register shutdown function as backup (for exit/die scenarios)
-        // This runs at the END of PHP execution, even after exit() or die()
-        if (! self::$shutdownRegistered) {
-            self::$shutdownRegistered = true;
-
-            register_shutdown_function(function () {
-                self::flushStatic();
-            });
-        }
+    /**
+     * @internal — see shutdownFunctionRegistered().
+     */
+    public static function markShutdownFunctionRegistered(): void
+    {
+        self::$shutdownRegistered = true;
     }
 
     /**

--- a/tests/Feature/EarlyTerminateCallbackTest.php
+++ b/tests/Feature/EarlyTerminateCallbackTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use LogScope\Logging\ChannelContextProcessor;
+use LogScope\LogScopeServiceProvider;
+use LogScope\Models\LogEntry;
+use LogScope\Services\LogBuffer;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    ChannelContextProcessor::clearLastChannel();
+    LogScopeServiceProvider::resetBufferState();
+    LogEntry::query()->delete();
+
+    config(['logscope.write_mode' => 'batch']);
+});
+
+it('flushes the buffer before a later-registered terminate callback that throws', function () {
+    Log::error('user log');
+
+    // Register a callback AFTER LogScope's (the service provider's eager
+    // registration). This simulates a user provider that registers a
+    // throwing terminate callback. Since LogScope is registered earlier
+    // in the chain, our flush runs first.
+    $this->app->terminating(function () {
+        throw new RuntimeException('later callback throws');
+    });
+
+    try {
+        $this->app->terminate();
+    } catch (\Throwable) {
+        // Expected — the user's callback threw. Our flush should already
+        // have completed by then.
+    }
+
+    // The user log should be in the DB despite the later throw.
+    expect(LogEntry::where('message', 'user log')->count())->toBe(1)
+        ->and(LogBuffer::getBuffer())->toBeEmpty();
+});
+
+it('the safe flush wrapper swallows its own exceptions instead of breaking the terminate chain', function () {
+    // Inject a single entry into the buffer, then break the DB so flushStatic's
+    // INSERT throws. Even so, the terminate() call must not propagate the
+    // exception — that would prevent OTHER providers' terminate callbacks
+    // from running.
+    $bufferProperty = (new ReflectionClass(LogBuffer::class))->getProperty('buffer');
+    $bufferProperty->setAccessible(true);
+    $bufferProperty->setValue(null, [['message' => 'doomed', 'level' => 'error']]);
+
+    \Illuminate\Support\Facades\Schema::drop('log_entries');
+
+    // Track that a SECOND callback (registered after LogScope's) actually runs.
+    $secondCallbackRan = false;
+    $this->app->terminating(function () use (&$secondCallbackRan) {
+        $secondCallbackRan = true;
+    });
+
+    $this->app->terminate();
+
+    expect($secondCallbackRan)->toBeTrue();
+
+    // Restore the table for subsequent tests.
+    $this->artisan('migrate', ['--path' => __DIR__.'/../../database/migrations']);
+});
+
+it('registers the Octane RequestTerminated listener when Octane is installed', function () {
+    if (! class_exists(\Laravel\Octane\Events\RequestTerminated::class)) {
+        $this->markTestSkipped('Laravel Octane is not installed in the test environment.');
+    }
+
+    expect($this->app['events']->hasListeners(\Laravel\Octane\Events\RequestTerminated::class))->toBeTrue();
+});

--- a/tests/Feature/EarlyTerminateCallbackTest.php
+++ b/tests/Feature/EarlyTerminateCallbackTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
 use LogScope\Logging\ChannelContextProcessor;
 use LogScope\LogScopeServiceProvider;
 use LogScope\Models\LogEntry;
@@ -17,6 +18,15 @@ beforeEach(function () {
     LogEntry::query()->delete();
 
     config(['logscope.write_mode' => 'batch']);
+});
+
+afterEach(function () {
+    // DDL operations (Schema::drop) don't roll back inside RefreshDatabase's
+    // transaction — re-create the table if a test dropped it so subsequent
+    // tests in this file aren't affected.
+    if (! Schema::hasTable('log_entries')) {
+        $this->artisan('migrate', ['--path' => __DIR__.'/../../database/migrations']);
+    }
 });
 
 it('flushes the buffer before a later-registered terminate callback that throws', function () {
@@ -51,7 +61,7 @@ it('the safe flush wrapper swallows its own exceptions instead of breaking the t
     $bufferProperty->setAccessible(true);
     $bufferProperty->setValue(null, [['message' => 'doomed', 'level' => 'error']]);
 
-    \Illuminate\Support\Facades\Schema::drop('log_entries');
+    Schema::drop('log_entries');
 
     // Track that a SECOND callback (registered after LogScope's) actually runs.
     $secondCallbackRan = false;
@@ -62,9 +72,7 @@ it('the safe flush wrapper swallows its own exceptions instead of breaking the t
     $this->app->terminate();
 
     expect($secondCallbackRan)->toBeTrue();
-
-    // Restore the table for subsequent tests.
-    $this->artisan('migrate', ['--path' => __DIR__.'/../../database/migrations']);
+    // Schema is restored by the file-level afterEach.
 });
 
 it('registers the Octane RequestTerminated listener when Octane is installed', function () {


### PR DESCRIPTION
## Summary

Closes original audit finding **#6**: an earlier-registered `terminating()` callback that throws prevents subsequent callbacks from running. Laravel's `Application::terminate()` iterates callbacks without try/catch around each — one throw kills the rest.

In CLI/HTTP, the `register_shutdown_function` safety net recovers. In **Octane**, the shutdown function only fires on worker death — buffered logs can sit for hours and may be lost if the worker is killed.

## Fix

Three changes:

1. **Eager registration.** Move terminate-callback wiring from `LogBuffer::add()` (lazy, on first log) to `LogScopeServiceProvider::register()` (eager). This puts our callback as early in the user-provider phase as possible — most other terminate callbacks register AFTER ours and can't skip us.

2. **Safe flush.** Wrap our flush in a closure that catches `Throwable` and `error_log()`s it. If the flush throws (e.g. transient DB error), we don't propagate the exception — so OUR callback can't break OTHER terminate callbacks downstream.

3. **Octane `RequestTerminated`.** For Octane specifically, listen on `Laravel\Octane\Events\RequestTerminated` as an independent flush trigger that survives even when Laravel's terminate callback chain is broken. Only registers if Octane is installed.

## Test plan

`tests/Feature/EarlyTerminateCallbackTest.php`:

- [x] **Flush before throw**: fire a log, register a throwing callback AFTER LogScope's, call `terminate()`, assert the log landed despite the throw
- [x] **Safe flush isolation**: drop the table, inject a buffer entry, register a tracking callback after ours, call `terminate()`, assert the tracking callback still ran (our throw didn't kill the chain)
- [x] **Octane listener registered when present** (skipped when Octane is absent)

Verified:
- [x] Full suite: 170 passed, 2 skipped (Octane absent), 431 assertions
- [x] Pint clean

## Backwards compatibility

`LogBuffer::add()` no longer triggers callback registration — that now happens at service-provider register time. No public API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)