### PR TITLE
Re-add narrow PHP-deprecation message-pattern filter as fallback

### DIFF
--- a/src/Services/LogCapture.php
+++ b/src/Services/LogCapture.php
@@ -139,15 +139,30 @@ class LogCapture
     {
         // Check if we should ignore deprecation messages.
         //
-        // Scope by CHANNEL — Laravel routes PHP runtime deprecations through
-        // a dedicated channel (default name 'deprecations'). The set of
-        // channels treated as deprecation channels is configurable so apps
-        // that remap the channel name still get the filter. Matching on
-        // the message substring "is deprecated" was unsafe: it silently
-        // dropped legitimate business logs that used the same phrase.
-        if (config('logscope.ignore.deprecations', false) && $channel !== null) {
+        // Two-layer match:
+        //
+        // 1) CHANNEL match (preferred) — PHP runtime deprecations route
+        //    through Laravel's `deprecations` channel. If the channel
+        //    processor is registered for it, we match by name.
+        //
+        // 2) MESSAGE-PATTERN fallback — Laravel's HandleExceptions
+        //    synthesizes the `deprecations` channel lazily, AFTER our
+        //    channel processor registration has run, so the processor
+        //    isn't attached and `$channel` is null/empty for these.
+        //    Fall back to matching the precise PHP deprecation format:
+        //    every PHP-runtime deprecation wraps as
+        //      "<actual message> in <file> on line <N>"
+        //    So we look for "is deprecated" + "on line <N>" at the end.
+        //    This is narrow enough that user logs like "Account 42 is
+        //    deprecated for billing" still pass through.
+        if (config('logscope.ignore.deprecations', false)) {
             $deprecationChannels = (array) config('logscope.ignore.deprecation_channels', ['deprecations']);
-            if (in_array($channel, $deprecationChannels, true)) {
+
+            if ($channel !== null && in_array($channel, $deprecationChannels, true)) {
+                return true;
+            }
+
+            if ($this->looksLikePhpDeprecation($event->message)) {
                 return true;
             }
         }
@@ -160,5 +175,30 @@ class LogCapture
         }
 
         return false;
+    }
+
+    /**
+     * Match Laravel's wrapped PHP-deprecation message format precisely.
+     *
+     * Laravel's HandleExceptions::handleDeprecation() formats the message as
+     *   "<original message> in <file> on line <N>"
+     * before logging through the deprecations channel. The original
+     * message itself contains "is deprecated" (the PHP-runtime phrase).
+     *
+     * Requiring BOTH parts (`is deprecated` somewhere + `on line <N>` at
+     * the end) is narrow enough to avoid the false-positives a plain
+     * substring match had:
+     *   - "Account 42 is deprecated for billing"  → no "on line N" → keep
+     *   - "Migration is DEPRECATED"               → no "on line N" → keep
+     *   - "strpos(): ... is deprecated in /path/x.php on line 42" → drop
+     */
+    protected function looksLikePhpDeprecation(string $message): bool
+    {
+        // Cheap pre-check before regex
+        if (! str_contains($message, 'is deprecated')) {
+            return false;
+        }
+
+        return (bool) preg_match('/ on line \d+$/', $message);
     }
 }

--- a/tests/Feature/LogFilterFalsePositivesTest.php
+++ b/tests/Feature/LogFilterFalsePositivesTest.php
@@ -109,9 +109,9 @@ describe('ignore.deprecations substring false positive', function () {
 
         setChannelAsFresh('application');
 
-        // 'application' isn't in the deprecation_channels list — the log must
-        // be captured even though the message mentions deprecation (the old
-        // substring filter would have dropped it).
+        // 'application' isn't in the deprecation_channels list and the
+        // message lacks the "on line N" suffix that PHP-runtime
+        // deprecations always have — log must be captured.
         event(new \Illuminate\Log\Events\MessageLogged(
             'warning',
             'feature flag x is deprecated',
@@ -119,5 +119,44 @@ describe('ignore.deprecations substring false positive', function () {
         ));
 
         expect(LogEntry::count())->toBe(1);
+    });
+
+    it('catches PHP runtime deprecations even when the channel processor was not attached', function () {
+        // Reproduces the production regression: Laravel's HandleExceptions
+        // synthesizes the `deprecations` channel lazily, AFTER our channel
+        // processor registration has already run. So when the deprecation
+        // fires, the channel processor isn't on it — $channel arrives as
+        // null. The channel-name match misses, but the message-pattern
+        // fallback catches Laravel's standard wrapped format.
+        config(['logscope.ignore.deprecations' => true]);
+
+        // Channel is null/empty (processor wasn't attached at boot time).
+        event(new \Illuminate\Log\Events\MessageLogged(
+            'warning',
+            'strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /vendor/pkg/file.php on line 42',
+            []
+        ));
+
+        expect(LogEntry::count())->toBe(0);
+    });
+
+    it('keeps capturing user logs that say "is deprecated" but lack the "on line N" suffix', function () {
+        // Locks in the contract that the message-pattern fallback is
+        // narrow — only matches PHP's wrapped format ending in
+        // "on line <N>". Business logs don't have that suffix.
+        config(['logscope.ignore.deprecations' => true]);
+
+        $messages = [
+            'This account is deprecated for billing',
+            'Migration is DEPRECATED — switch to new endpoint',
+            'API endpoint /v1/users is deprecated, use /v2',
+            'feature flag x is deprecated',
+        ];
+
+        foreach ($messages as $message) {
+            event(new \Illuminate\Log\Events\MessageLogged('warning', $message, []));
+        }
+
+        expect(LogEntry::count())->toBe(count($messages));
     });
 });


### PR DESCRIPTION
## Production regression

In v1.5.5+ the deprecations filter (`logscope.ignore.deprecations`) stopped catching Laravel's PHP runtime deprecations. Reproduced in playground:

\`\`\`
Log::channel('deprecations')->warning('...is deprecated in /vendor/pkg/file.php on line 42');
LogEntry::first()->channel  // → empty/null (channel processor wasn't attached)
\`\`\`

## Root cause

PR #8 made the filter channel-scoped (`channel === 'deprecations'`). The intent was correct: Laravel's `HandleExceptions::handleDeprecation()` does `\$logger->channel('deprecations')->warning(...)`.

What I missed: **timing.** Laravel's `ensureDeprecationLoggerIsConfigured()` synthesizes the `deprecations` channel **lazily**, the first time a deprecation fires. By then our `registerChannelProcessor()` has already iterated `config('logging.channels')` and added taps. The deprecations channel isn't there yet, so no tap is attached, the channel processor doesn't fire for those logs, and `\$channel` arrives as null in the listener. The channel-name match never triggers.

## Fix

Re-add a narrow message-pattern check as a fallback. Laravel wraps deprecation messages as:

> `<original message> in <file> on line <N>`

We match on **`is deprecated`** + **`on line <N>` at the end**. That's narrow enough to avoid the false positives PR #8 removed:

| Message | Old (v1.5.4) | v1.5.5+ | This PR |
|---|---|---|---|
| `strpos(): … is deprecated in /v/x on line 42` | drop | **keep (BUG)** | drop |
| `Account 42 is deprecated for billing` | drop (false positive) | keep | keep |
| `Migration is DEPRECATED — switch endpoint` | keep (case) | keep | keep |
| `API endpoint /v1/users is deprecated` | drop (false positive) | keep | keep |

Two-layer match: channel-name first (still works for users whose Laravel registers the channel eagerly), message-pattern fallback (catches the lazy-channel case). Either match filters; both have to miss for the log to be captured.

## Test plan

\`tests/Feature/LogFilterFalsePositivesTest.php\` — two new tests:

- [x] **catches PHP runtime deprecations even when the channel processor was not attached** — reproduces the prod regression
- [x] **keeps capturing user logs that say "is deprecated" but lack the "on line N" suffix** — locks in the false-positive guarantees with 4 example messages

Verified:
- [x] Full suite: 183 passed, 2 skipped (Octane), 462 assertions
- [x] Pint clean
- [x] Manual playground reproduction: PHP-style deprecation dropped, business logs kept

🤖 Generated with [Claude Code](https://claude.com/claude-code)