### PR TITLE
Isolate captureContext callback errors from the log-write path

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,14 +508,21 @@ Add custom data to every log entry (e.g., API token ID, tenant ID):
 use LogScope\LogScope;
 
 LogScope::captureContext(function ($request) {
+    $token = $request->user()?->currentAccessToken();
+
     return [
-        'token_id' => $request->user()?->currentAccessToken()?->id,
+        // Sanctum returns TransientToken (no `id`) for session-authenticated
+        // requests and PersonalAccessToken (has `id`) for token-authenticated
+        // requests. Type-check before accessing.
+        'token_id' => $token instanceof \Laravel\Sanctum\PersonalAccessToken ? $token->id : null,
         'tenant_id' => $request->user()?->tenant_id,
     ];
 });
 ```
 
 This data is merged into the log's `context` field and appears in the JSON viewer.
+
+If your callback throws (a property access on the wrong type, an unbound service, etc.), LogScope catches the exception, drops the custom context for that log entry only, and adds `_logscope_callback_error` to the entry's context with the exception class + message. The original log is still captured. The callback failure is also surfaced via `error_log()` and the in-UI failure banner so you know the callback is broken.
 
 ### Artisan Commands
 

--- a/src/LogScope.php
+++ b/src/LogScope.php
@@ -182,15 +182,32 @@ class LogScope
     /**
      * Get the additional captured context for the given request.
      *
+     * Wraps the user-registered callback in a try/catch so a buggy
+     * callback (e.g. accessing `currentAccessToken()->id` when Sanctum
+     * returned a TransientToken with no `id` property) doesn't cascade
+     * into losing the underlying log entry. On failure we return an
+     * empty array AND surface a one-shot error_log breadcrumb so the
+     * user knows their callback is broken — but we keep the original
+     * log captured.
+     *
      * @return array<string, mixed>
      */
     public static function getCapturedContext(Request $request): array
     {
-        if (static::$captureContextUsing !== null) {
-            return (static::$captureContextUsing)($request) ?? [];
+        if (static::$captureContextUsing === null) {
+            return [];
         }
 
-        return [];
+        try {
+            return (static::$captureContextUsing)($request) ?? [];
+        } catch (\Throwable $e) {
+            \LogScope\Services\WriteFailureLogger::report($e, 'captureContext-callback');
+
+            // Return an empty array so the original log still lands.
+            // Add a marker the user can search for in the captured
+            // entry's context to know which logs were affected.
+            return ['_logscope_callback_error' => get_class($e).': '.$e->getMessage()];
+        }
     }
 
     /**

--- a/tests/Unit/LogScopeTest.php
+++ b/tests/Unit/LogScopeTest.php
@@ -77,6 +77,27 @@ it('resets capture context callback', function () {
     expect($context)->toBe([]);
 });
 
+it('isolates a throwing capture-context callback so the underlying log still lands', function () {
+    // Reproduces the production case: a Sanctum TransientToken doesn't
+    // have an `id` property, so accessing `->id` on it throws an
+    // ErrorException. Without isolation, that throw cascades into the
+    // outer write try/catch and the original log is silently lost.
+    LogScope::captureContext(function ($request) {
+        $obj = new \stdClass; // no `id` property — accessing throws via __get? actually returns null on stdClass
+        // Force a real Undefined-property-style error via throw
+        throw new \ErrorException('Undefined property: Laravel\\Sanctum\\TransientToken::$id');
+    });
+
+    $request = Request::create('/test');
+    $context = LogScope::getCapturedContext($request);
+
+    // Empty context (since the callback failed) PLUS a marker key so
+    // the user can see which entries were affected.
+    expect($context)->toHaveKey('_logscope_callback_error')
+        ->and($context['_logscope_callback_error'])->toContain('ErrorException')
+        ->and($context['_logscope_callback_error'])->toContain('Undefined property');
+});
+
 it('returns null when no statusChangedBy callback is set and no user', function () {
     $request = Request::create('/test');
 


### PR DESCRIPTION
## Production report

A user reported the in-UI failure banner showing:

> LogScope has had 33 write failures recently. Last error: \`[ErrorException] Undefined property: Laravel\\Sanctum\\TransientToken::\$id\` · Source: listener

## Root cause

This is a **user-side bug in their `captureContext` callback** — they used the README's example pattern:

\`\`\`php
'token_id' => \$request->user()?->currentAccessToken()?->id,
\`\`\`

When Sanctum auths via session (not a personal access token), `currentAccessToken()` returns a `TransientToken` which has **no `id` property**. Accessing `->id` throws `ErrorException`.

**But our pipeline made it worse.** When the callback threw, the throw bubbled into `LogCapture::buildLogData()`'s outer try/catch, which:

1. Reported it as a **"write failure"** (misleading — the write never happened)
2. **Silently lost the original log entry** (we threw before `writer->write()` was called)

## Fix

Wrap the `captureContext` callback invocation in its own try/catch inside `LogScope::getCapturedContext`. On failure:

- Return `['_logscope_callback_error' => 'ExceptionClass: message']` so the underlying log **still lands** with a marker the user can search for to identify affected entries
- Surface the failure via `WriteFailureLogger::report()` with a distinct source label `captureContext-callback` so it shows up in the in-UI banner under its true category (not as "listener" / "write failure")

Also update the README's example to type-check before accessing token properties:

\`\`\`php
\$token = \$request->user()?->currentAccessToken();
'token_id' => \$token instanceof \\Laravel\\Sanctum\\PersonalAccessToken ? \$token->id : null,
\`\`\`

And add a paragraph documenting the new "callback failure" semantics.

## Test plan

\`tests/Unit/LogScopeTest.php\` — new test:

- [x] **isolates a throwing capture-context callback so the underlying log still lands** — registers a callback that throws an ErrorException, verifies `getCapturedContext` returns `['_logscope_callback_error' => '...']` instead of letting the throw escape

Verified:
- [x] Full suite: 184 passed, 2 skipped (Octane), 465 assertions
- [x] Pint clean
- [x] All 9 existing capture-context tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)