### PR TITLE
Update Watchtower integration references (renamed from logscope-guard)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to LogScope are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Watchtower integration** (formerly LogScope Guard) — README install command, the JS `guard` flag, and the `@includeIf` partial now point at `ahmedmerza/laravel-watchtower` and the `watchtower::` view namespace / `watchtower.*` config namespace. The companion package was renamed; LogScope users following the README will install the new package, and the in-detail-panel Block-IP button activates against the new namespaces. **Breaking only for users on the unreleased pre-rename Guard package** — anyone who already shipped the integration on top of `ahmedmerza/logscope-guard` (≤ v0.1.0) will see the Block-IP button stop appearing until they upgrade Guard to Watchtower.
+
 ## [1.6.0] — 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -743,16 +743,16 @@ LOGSCOPE_REDACT_SENSITIVE=true
 
 ## 🛡️ Extensions
 
-### LogScope Guard
+### Watchtower
 
-Block malicious IPs directly from the LogScope UI and sync the blacklist across all your environments automatically.
+Block malicious IPs directly from the LogScope UI and sync the blacklist across all your environments automatically. (Previously named `ahmedmerza/logscope-guard`.)
 
 ```bash
-composer require ahmedmerza/logscope-guard
-php artisan guard:install
+composer require ahmedmerza/laravel-watchtower
+php artisan watchtower:install
 ```
 
-[View LogScope Guard →](https://github.com/AhmedMerza/laravel-logscope-guard)
+[View Watchtower →](https://github.com/AhmedMerza/laravel-watchtower)
 
 ---
 

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -47,7 +47,7 @@ window.logScopeConfig = {
     channels: @json($channels),
     forbiddenRedirect: @json(config('logscope.routes.forbidden_redirect', '/')),
     unauthenticatedRedirect: @json(config('logscope.routes.unauthenticated_redirect', '/login')),
-    guard: @json(config('logscope-guard.enabled', false)),
+    guard: @json(config('watchtower.enabled', false)),
     routes: {
         logs: '{{ route('logscope.logs') }}',
         stats: '{{ route('logscope.stats') }}',

--- a/resources/views/partials/detail-panel.blade.php
+++ b/resources/views/partials/detail-panel.blade.php
@@ -196,7 +196,7 @@
         </div>
     </div>
 
-    @includeIf('logscope-guard::partials.ip-actions', [])
+    @includeIf('watchtower::partials.ip-actions', [])
 
     <!-- Panel Footer -->
     <div class="flex flex-wrap sm:flex-nowrap items-center gap-2 px-4 py-3 border-t border-[var(--border)]">

--- a/tests/Feature/WatchtowerIntegrationTest.php
+++ b/tests/Feature/WatchtowerIntegrationTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use LogScope\LogScope;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    // Force the array cache driver — Testbench's default `database` cache
+    // would hit a `cache` table that the test SQLite DB doesn't have.
+    config(['cache.default' => 'array']);
+    Cache::flush();
+
+    // Bypass LogScope's authorize middleware in test env (default check
+    // requires 'local' env, but Testbench uses 'testing').
+    LogScope::auth(fn () => true);
+});
+
+afterEach(function (): void {
+    LogScope::resetAuth();
+});
+
+/*
+ * These tests pin the Watchtower integration contract so a future rename
+ * (on either side) fails loudly instead of silently disabling the in-detail
+ * Block-IP button. The contract is:
+ *
+ *   LogScope's dashboard reads `config('watchtower.enabled')` and exposes
+ *   it as the boolean `guard` flag in `window.logScopeConfig`. Watchtower's
+ *   ip-actions partial reads the same flag to decide whether to render.
+ *
+ * If LogScope ever renames the JS field or the config key it reads, these
+ * tests fail and the change is forced to coordinate with Watchtower.
+ */
+
+it('exposes watchtower.enabled as guard: true in the JS config when the flag is set', function (): void {
+    config(['watchtower.enabled' => true]);
+
+    $response = $this->get('/logscope');
+
+    $response->assertOk();
+    $response->assertSee('guard: true', escape: false);
+});
+
+it('exposes guard: false when watchtower is not installed (config namespace empty)', function (): void {
+    // Simulate Watchtower not installed — its config namespace doesn't exist.
+    config(['watchtower' => []]);
+
+    $response = $this->get('/logscope');
+
+    $response->assertOk();
+    $response->assertSee('guard: false', escape: false);
+});
+
+it('exposes guard: false when watchtower is installed but explicitly disabled', function (): void {
+    config(['watchtower.enabled' => false]);
+
+    $response = $this->get('/logscope');
+
+    $response->assertOk();
+    $response->assertSee('guard: false', escape: false);
+});


### PR DESCRIPTION
## Summary

The companion package was renamed from `ahmedmerza/logscope-guard` → `ahmedmerza/laravel-watchtower`. Three integration points in this repo needed updating to match:

- **README §Extensions** — install command and link now point at `ahmedmerza/laravel-watchtower` + the new GitHub repo URL. Brief note that it was previously named `logscope-guard` so anyone landing from old links gets context.
- **`resources/views/index.blade.php`** — `window.logScopeConfig.guard` now reads from `config('watchtower.enabled')` instead of `config('logscope-guard.enabled')`. **Without this, the guard flag was always false post-rename** and the Block-IP button JS path never activated.
- **`resources/views/partials/detail-panel.blade.php`** — `@includeIf` now points at the `watchtower::` view namespace. The old `logscope-guard::` namespace is no longer registered by the renamed package, so the include silently rendered nothing.

## Breaking impact

Only for users running pre-rename Guard (≤ v0.1.0). They need to upgrade Guard to Watchtower for the Block-IP button to keep appearing. v0.1.0 had near-zero usage so this is acceptable as part of the broader rename rollout.

## Test plan

- [x] `composer test` — 190 passed (+ 11 pre-existing FailureBannerTest failures unrelated to this PR)
- [ ] Reviewer: pull both branches (`laravel-logscope#19` and `laravel-watchtower` post-merge), install in playground, confirm the Block-IP button appears in the detail panel
- [ ] Reviewer: confirm `window.logScopeConfig.guard === true` in browser devtools when Watchtower is installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)