### PR TITLE
Surface write failures as fallback rows in log_entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] — 2026-05-13
+
 ### Added
 
 - **Write-failure fallback rows in `log_entries`.** When the normal write path throws (e.g. context sanitization touches a class the autoloader can't resolve, or a bulk insert blows up mid-flush), LogScope now writes a minimal marker row to `log_entries` so the failure shows up in the UI — not just in php-fpm's `error_log`. The marker row preserves the original `level`/`message`/`channel`/`trace_id` (re-read from request context if buildLogData itself threw, so correlation survives) and replaces `context` with a `_logscope_write_failure` block carrying the exception class, message, call-site label, and an occurrence counter. Per-process dedupe with a heartbeat every 100th occurrence keeps a sustained outage from flooding the table while still giving the operator a "still happening" signal. Wired into all three write modes (sync via `LogCapture`, queue via `WriteLogEntry::handle`, batch via `LogBuffer::performFlush`). Octane request-boundary listener now also resets `FallbackWriter`'s static map so long-running workers don't strand their dedupe state across requests. New config: `logscope.write_failure.persist_fallback` (default `true`, env `LOGSCOPE_WRITE_FAILURE_PERSIST_FALLBACK`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Write-failure fallback rows in `log_entries`.** When the normal write path throws (e.g. context sanitization touches a class the autoloader can't resolve, or a bulk insert blows up mid-flush), LogScope now writes a minimal marker row to `log_entries` so the failure shows up in the UI — not just in php-fpm's `error_log`. The marker row preserves the original `level`/`message`/`channel`/`trace_id` (re-read from request context if buildLogData itself threw, so correlation survives) and replaces `context` with a `_logscope_write_failure` block carrying the exception class, message, call-site label, and an occurrence counter. Per-process dedupe with a heartbeat every 100th occurrence keeps a sustained outage from flooding the table while still giving the operator a "still happening" signal. Wired into all three write modes (sync via `LogCapture`, queue via `WriteLogEntry::handle`, batch via `LogBuffer::performFlush`). Octane request-boundary listener now also resets `FallbackWriter`'s static map so long-running workers don't strand their dedupe state across requests. New config: `logscope.write_failure.persist_fallback` (default `true`, env `LOGSCOPE_WRITE_FAILURE_PERSIST_FALLBACK`).
+
+### Changed
+
+- **Queue worker retry behavior.** `WriteLogEntry::handle` now classifies failures: SQLSTATE classes `08*` (connection) and `40*` (deadlock/serialization) re-throw so Laravel's queue retries kick in; everything else (autoload errors, schema mismatches, malformed data) is treated as persistent — recorded via the fallback row and `WriteFailureLogger`, then swallowed so a poisoned entry can't loop the worker forever. Previously every failure surfaced as a job-level exception, triggering unbounded retries on bugs that retries couldn't fix.
+
 ## [1.6.1] — 2026-05-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Queue worker retry behavior.** `WriteLogEntry::handle` now classifies failures: SQLSTATE classes `08*` (connection) and `40*` (deadlock/serialization) re-throw so Laravel's queue retries kick in; everything else (autoload errors, schema mismatches, malformed data) is treated as persistent — recorded via the fallback row and `WriteFailureLogger`, then swallowed so a poisoned entry can't loop the worker forever. Previously every failure surfaced as a job-level exception, triggering unbounded retries on bugs that retries couldn't fix.
+- **`LogBuffer::performFlush` error isolation improved per-chunk.** `LogEntry::prepareData()` is now called inside the per-chunk try block (previously it ran once over the entire buffer up front). A single malformed entry now loses only its 500-row chunk, not the whole buffer. No config change required — strictly fewer entries lost on the failure path.
 
 ## [1.6.1] — 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Visit `/logscope` in your browser. That's it!
 
 ## What's New
 
-**Latest: [v1.6.1](https://github.com/AhmedMerza/laravel-logscope/releases/tag/v1.6.1)** — Default to `sync` write mode in the testing environment so consumer test suites stop seeing the noisy "Discarded N buffered log entries" warning + silent log loss; Watchtower integration rename (formerly LogScope Guard).
+**Latest: [v1.7.0](https://github.com/AhmedMerza/laravel-logscope/releases/tag/v1.7.0)** — Write failures now surface as fallback rows in `log_entries` so they appear in the LogScope UI instead of vanishing into `error_log`; queue worker retry semantics tightened to distinguish transient DB errors (retry) from persistent code/autoload bugs (record + swallow).
 
 See [CHANGELOG.md](CHANGELOG.md) for full release history and behavior-change notes.
 

--- a/config/logscope.php
+++ b/config/logscope.php
@@ -189,9 +189,14 @@ return [
     |
     | The fallback row keeps the original level/message/channel/trace_id and
     | replaces `context` with a `_logscope_write_failure` marker carrying the
-    | exception class, message, and call-site label. Per-process dedupe
-    | guarantees at most one fallback row per unique throw site, so a
-    | sustained outage doesn't flood the table.
+    | exception class, message, call-site label, and occurrence counter.
+    |
+    | Dedupe: per-process counter keyed on exception class + throw site. A
+    | row is emitted on the first occurrence and every 100th thereafter,
+    | so a sustained outage stays visible in the UI (heartbeat) without
+    | flooding the table. Octane workers reset the counter at request
+    | boundaries so the dedupe scopes to the request, not the worker
+    | lifetime.
     |
     | 'persist_fallback' - Toggle the fallback row. Disable if you prefer to
     |                      rely on error_log + cache banner alone.

--- a/config/logscope.php
+++ b/config/logscope.php
@@ -179,6 +179,30 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Write Failure Fallback
+    |--------------------------------------------------------------------------
+    |
+    | When the normal write path throws (e.g. an autoload error inside context
+    | sanitization, or a bulk insert blowing up mid-flush), LogScope can write
+    | a minimal *fallback* row to log_entries so the failure shows up in the
+    | UI alongside everything else — not just in php-fpm's error_log.
+    |
+    | The fallback row keeps the original level/message/channel/trace_id and
+    | replaces `context` with a `_logscope_write_failure` marker carrying the
+    | exception class, message, and call-site label. Per-process dedupe
+    | guarantees at most one fallback row per unique throw site, so a
+    | sustained outage doesn't flood the table.
+    |
+    | 'persist_fallback' - Toggle the fallback row. Disable if you prefer to
+    |                      rely on error_log + cache banner alone.
+    |
+    */
+    'write_failure' => [
+        'persist_fallback' => env('LOGSCOPE_WRITE_FAILURE_PERSIST_FALLBACK', true),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Features
     |--------------------------------------------------------------------------
     |

--- a/src/Jobs/WriteLogEntry.php
+++ b/src/Jobs/WriteLogEntry.php
@@ -6,11 +6,15 @@ namespace LogScope\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use LogScope\Models\LogEntry;
+use LogScope\Services\FallbackWriter;
+use LogScope\Services\WriteFailureLogger;
 use LogScope\Services\WriteGuard;
+use Throwable;
 
 class WriteLogEntry implements ShouldQueue
 {
@@ -41,6 +45,51 @@ class WriteLogEntry implements ShouldQueue
      */
     public function handle(): void
     {
-        WriteGuard::during(fn () => LogEntry::createEntry($this->data));
+        try {
+            WriteGuard::during(fn () => LogEntry::createEntry($this->data));
+        } catch (Throwable $e) {
+            // Transient DB conditions (connection failures, deadlocks) are
+            // exactly what queue retries exist for — let Laravel re-run the
+            // job. No fallback row in this branch: if the retry succeeds
+            // we'd otherwise have a duplicate (one fallback + one real).
+            if ($this->isTransientFailure($e)) {
+                throw $e;
+            }
+
+            // Persistent failure (autoload error, schema mismatch, malformed
+            // data). Retrying won't help and would loop the worker, so we
+            // swallow after recording observability:
+            //   - WriteFailureLogger → error_log + cache banner
+            //   - FallbackWriter      → minimal row in log_entries
+            WriteFailureLogger::report($e, 'queue-worker');
+
+            try {
+                app(FallbackWriter::class)->record($this->data, $e, 'queue-worker');
+            } catch (Throwable) {
+                // last-resort: error_log already covered observability
+            }
+        }
+    }
+
+    /**
+     * Classify a write failure as transient (retry-eligible) or
+     * persistent. We treat ONLY SQLSTATE classes 08 (Connection Exception)
+     * and 40 (Transaction Rollback — 40001 serialization failure / 40P01
+     * postgres deadlock) as transient. Everything else is assumed to be
+     * a code/data problem where a retry would just fail the same way.
+     *
+     * Non-QueryException throws (TypeError, autoload failures, etc.)
+     * are always persistent — those are the cases that motivated the
+     * fallback row in the first place.
+     */
+    private function isTransientFailure(Throwable $e): bool
+    {
+        if (! $e instanceof QueryException) {
+            return false;
+        }
+
+        $sqlState = (string) $e->getCode();
+
+        return str_starts_with($sqlState, '08') || str_starts_with($sqlState, '40');
     }
 }

--- a/src/LogScopeServiceProvider.php
+++ b/src/LogScopeServiceProvider.php
@@ -19,6 +19,7 @@ use LogScope\Contracts\LogWriterInterface;
 use LogScope\Http\Middleware\CaptureRequestContext;
 use LogScope\Logging\AddChannelToContext;
 use LogScope\Services\ContextSanitizer;
+use LogScope\Services\FallbackWriter;
 use LogScope\Services\LogBuffer;
 use LogScope\Services\LogCapture;
 use LogScope\Services\LogWriter;
@@ -99,10 +100,15 @@ class LogScopeServiceProvider extends ServiceProvider
         });
         $this->app->alias(LogWriter::class, LogWriterInterface::class);
 
+        $this->app->singleton(FallbackWriter::class, function () {
+            return new FallbackWriter;
+        });
+
         $this->app->singleton(LogCapture::class, function ($app) {
             return new LogCapture(
                 $app->make(LogWriterInterface::class),
-                $app->make(ContextSanitizerInterface::class)
+                $app->make(ContextSanitizerInterface::class),
+                $app->make(FallbackWriter::class)
             );
         });
     }
@@ -254,13 +260,21 @@ class LogScopeServiceProvider extends ServiceProvider
     }
 
     /**
-     * Reset static channel state at Octane request boundaries.
+     * Reset static state at Octane request boundaries.
      *
-     * Octane keeps the worker process alive across requests. The Monolog
-     * channel processor stores the last channel name in static state.
-     * Without this listener, a Log::build() log in request N+1 could
-     * inherit the channel of request N's last log if a Monolog handler
-     * threw (or any other rare path that orphaned `$isFresh=true`).
+     * Octane keeps the worker process alive across requests, so any
+     * per-process static state will leak across them unless we clear it.
+     * Two consumers today:
+     *
+     * - ChannelContextProcessor's "last channel" slot — without reset,
+     *   a Log::build() log in request N+1 could inherit the channel of
+     *   request N's last log if a Monolog handler threw.
+     *
+     * - FallbackWriter's per-failure occurrence map — without reset, a
+     *   long-running worker would only ever emit ONE fallback row per
+     *   failure key for its entire lifetime (minus heartbeats every
+     *   REEMIT_EVERY). Resetting per-request scopes the dedupe to the
+     *   request, matching the natural mental model for ops dashboards.
      *
      * Only registers if Laravel\Octane\Events\RequestReceived exists —
      * Octane is an optional peer, not a hard dependency.
@@ -275,6 +289,7 @@ class LogScopeServiceProvider extends ServiceProvider
             \Laravel\Octane\Events\RequestReceived::class,
             function (): void {
                 \LogScope\Logging\ChannelContextProcessor::clearLastChannel();
+                FallbackWriter::reset();
             }
         );
     }

--- a/src/Services/FallbackWriter.php
+++ b/src/Services/FallbackWriter.php
@@ -67,6 +67,19 @@ class FallbackWriter
      * and wrapped in WriteGuard so the listener doesn't re-capture the
      * insert. If the fallback insert itself fails, we silently swallow —
      * WriteFailureLogger has already emitted the failure to error_log.
+     *
+     * Counter semantics — the occurrence counter is incremented BEFORE the
+     * emit attempt, not after. This means the counter reflects "occurrences
+     * the writer has seen," not "rows successfully persisted." Consequence:
+     * if the first-occurrence emit fails (e.g. DB gone at shutdown), the
+     * next emit attempt isn't until the 100th occurrence — there's no
+     * automatic retry of the missed row. We accept that trade-off because:
+     * (1) WriteFailureLogger's error_log line is the canonical signal at
+     * shutdown and stays reliable when the DB is unreachable, and (2) the
+     * alternative (pre-check + post-increment-on-success) re-tries every
+     * call when the cause is persistent, which means N wasted insert
+     * attempts for a sustained outage instead of N/100. The error_log
+     * dedupe also caps at one line per 100 occurrences for the same reason.
      */
     public function record(array $data, Throwable $e, string $where): void
     {

--- a/src/Services/FallbackWriter.php
+++ b/src/Services/FallbackWriter.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LogScope\Services;
+
+use Illuminate\Log\Events\MessageLogged;
+use Illuminate\Support\Facades\Context;
+use LogScope\Models\LogEntry;
+use Throwable;
+
+/**
+ * Writes a minimal failure-marker row to log_entries when LogScope's
+ * normal write path throws (e.g. context sanitization touches a class
+ * the autoloader can't resolve, or the bulk insert blows up mid-flush).
+ *
+ * Why this exists: WriteFailureLogger surfaces the failure to PHP's
+ * error_log and a cache breadcrumb, but operators live in the LogScope
+ * UI. A row in log_entries makes the failure visible there — same place
+ * everything else shows up — without needing to grep php-fpm logs.
+ *
+ * What gets dropped: the original `context` array. That's the usual
+ * poison source — sanitized objects whose serialization triggered the
+ * underlying error. The fallback row replaces it with a structured
+ * marker carrying the exception class, message, and call-site label.
+ *
+ * Dedupe: per-process counter map keyed on `exceptionClass@file:line`,
+ * mirroring WriteFailureLogger. A row is emitted on the first occurrence
+ * and every REEMIT_EVERY (100th) occurrence thereafter, so a sustained
+ * outage shows a steady heartbeat in the UI rather than going silent
+ * after the first row. Octane workers call reset() on RequestReceived
+ * so the dedupe scopes to the request, not the worker's lifetime.
+ */
+class FallbackWriter
+{
+    /**
+     * Per-process occurrence counter: failure key => count.
+     *
+     * Tracks how many times each unique throw site has fired in this
+     * process so we can emit a heartbeat row every Nth occurrence (see
+     * REEMIT_EVERY). Counts grow unboundedly across the worker lifetime,
+     * but the key space is bounded by distinct throw sites in the
+     * codebase — finite in practice.
+     */
+    private static array $seen = [];
+
+    /**
+     * Cap the persisted exception message — production messages can
+     * carry full SQL/stack snippets, and this row exists for visibility,
+     * not forensics.
+     */
+    private const MAX_MESSAGE_LENGTH = 1000;
+
+    /**
+     * Emit a fresh fallback row on the first occurrence and every Nth
+     * occurrence thereafter. Mirrors WriteFailureLogger::SUMMARY_EVERY
+     * so a long-running outage doesn't go silent in the UI after the
+     * first row — the operator gets a heartbeat that the issue is still
+     * happening.
+     */
+    private const REEMIT_EVERY = 100;
+
+    /**
+     * Write a fallback row carrying the original level/message/channel/
+     * trace_id, with `context` replaced by a `_logscope_write_failure`
+     * marker. Best-effort: gated by config flag, deduped per-process,
+     * and wrapped in WriteGuard so the listener doesn't re-capture the
+     * insert. If the fallback insert itself fails, we silently swallow —
+     * WriteFailureLogger has already emitted the failure to error_log.
+     */
+    public function record(array $data, Throwable $e, string $where): void
+    {
+        if (! $this->isPersistEnabled()) {
+            return;
+        }
+
+        $key = get_class($e).'@'.$e->getFile().':'.$e->getLine();
+        $count = (self::$seen[$key] ?? 0) + 1;
+        self::$seen[$key] = $count;
+
+        // Emit on first occurrence and every REEMIT_EVERY thereafter.
+        // Between heartbeats the row would be a near-duplicate, so we skip.
+        if ($count !== 1 && $count % self::REEMIT_EVERY !== 0) {
+            return;
+        }
+
+        try {
+            WriteGuard::during(fn () => LogEntry::createEntry($this->buildPayload($data, $e, $where, $count)));
+        } catch (Throwable) {
+            // Last-resort: the failure has already been surfaced to error_log
+            // by WriteFailureLogger::report. Don't recurse into another error.
+        }
+    }
+
+    /**
+     * Build a fallback payload from a MessageLogged event. Used when the
+     * normal write path failed BEFORE buildLogData could finish — so
+     * there's no sanitized `$data` array yet, only the raw event.
+     *
+     * Pulls request context (trace_id/ip/url/method/agent) directly from
+     * Laravel's Context facade so the fallback row stays correlatable
+     * with the request that produced the failure. The whole point of
+     * the fallback is "see this failure in context"; losing trace_id
+     * would defeat it.
+     */
+    public function recordFromEvent(
+        MessageLogged $event,
+        ?string $channel,
+        Throwable $e,
+        string $where
+    ): void {
+        $requestContext = $this->readRequestContext();
+
+        $this->record([
+            'level' => $event->level,
+            'message' => $event->message,
+            'channel' => $channel,
+            'trace_id' => $requestContext['trace_id'] ?? null,
+            'ip_address' => $requestContext['ip_address'] ?? null,
+            'user_agent' => $requestContext['user_agent'] ?? null,
+            'http_method' => $requestContext['http_method'] ?? null,
+            'url' => $requestContext['url'] ?? null,
+        ], $e, $where);
+    }
+
+    /**
+     * Best-effort read of the request-scoped LogScope context. Returns
+     * an empty array when the Context facade is unavailable (CLI, very
+     * late shutdown, container teardown).
+     *
+     * @return array<string, mixed>
+     */
+    private function readRequestContext(): array
+    {
+        try {
+            $value = Context::get('logscope', []);
+
+            return is_array($value) ? $value : [];
+        } catch (Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * @internal — for tests and Octane request-boundary resets.
+     *
+     * Clears the per-process occurrence map so a long-running worker
+     * doesn't strand its dedupe state across request boundaries (which
+     * would mean only ever seeing the first failure for the worker's
+     * lifetime).
+     */
+    public static function reset(): void
+    {
+        self::$seen = [];
+    }
+
+    /**
+     * @internal — for tests
+     */
+    public static function occurrenceCount(Throwable $e): int
+    {
+        $key = get_class($e).'@'.$e->getFile().':'.$e->getLine();
+
+        return self::$seen[$key] ?? 0;
+    }
+
+    private function isPersistEnabled(): bool
+    {
+        try {
+            return (bool) config('logscope.write_failure.persist_fallback', true);
+        } catch (Throwable) {
+            return true;
+        }
+    }
+
+    /**
+     * Construct the minimal payload. Original metadata is preserved so
+     * the row threads correctly into trace/IP filters; `context` is
+     * replaced with the failure marker so re-sanitization can't fire
+     * the same trap that broke the original write.
+     */
+    private function buildPayload(array $data, Throwable $e, string $where, int $occurrence): array
+    {
+        return [
+            'level' => $data['level'] ?? 'error',
+            'message' => $data['message'] ?? '(unknown message)',
+            'channel' => $data['channel'] ?? null,
+            'trace_id' => $data['trace_id'] ?? null,
+            'user_id' => $data['user_id'] ?? null,
+            'ip_address' => $data['ip_address'] ?? null,
+            'user_agent' => $data['user_agent'] ?? null,
+            'http_method' => $data['http_method'] ?? null,
+            'url' => $data['url'] ?? null,
+            'occurred_at' => $data['occurred_at'] ?? now(),
+            'context' => [
+                '_logscope_write_failure' => [
+                    'exception_class' => get_class($e),
+                    'exception_message' => $this->truncate($e->getMessage(), self::MAX_MESSAGE_LENGTH),
+                    'where' => $where,
+                    'occurrence' => $occurrence,
+                ],
+            ],
+        ];
+    }
+
+    private function truncate(string $value, int $max): string
+    {
+        if (mb_strlen($value) <= $max) {
+            return $value;
+        }
+
+        return mb_substr($value, 0, $max).'… [truncated]';
+    }
+}

--- a/src/Services/LogBuffer.php
+++ b/src/Services/LogBuffer.php
@@ -162,19 +162,44 @@ class LogBuffer implements LogBufferInterface
      */
     protected static function performFlush(array $logsToFlush): void
     {
-        try {
-            $limits = self::$cachedLimits ?: config('logscope.limits', []);
-            $rows = array_map(fn ($data) => LogEntry::prepareData($data, $limits), $logsToFlush);
+        $limits = self::$cachedLimits ?: config('logscope.limits', []);
 
-            foreach (array_chunk($rows, 500) as $chunk) {
-                try {
-                    LogEntry::insert(self::normalizeChunk($chunk));
-                } catch (Throwable $e) {
-                    WriteFailureLogger::report($e, 'buffer-flush');
-                }
+        // Chunk over the ORIGINAL data array — not the post-prepareData rows —
+        // so each entry's level/message/channel/trace_id is still in hand if
+        // we need to emit fallback rows for a failed chunk. prepareData is
+        // applied per-chunk just in time.
+        foreach (array_chunk($logsToFlush, 500) as $originalChunk) {
+            try {
+                $rows = array_map(fn ($data) => LogEntry::prepareData($data, $limits), $originalChunk);
+                LogEntry::insert(self::normalizeChunk($rows));
+            } catch (Throwable $e) {
+                WriteFailureLogger::report($e, 'buffer-flush');
+                self::writeFallbackForChunk($originalChunk, $e);
             }
-        } catch (Throwable $e) {
-            WriteFailureLogger::report($e, 'buffer-flush');
+        }
+    }
+
+    /**
+     * Emit a fallback row per entry in a failed chunk. The FallbackWriter's
+     * per-process dedupe collapses the per-row calls to one row per unique
+     * throw site, so a 500-entry chunk failing on a single autoload bug
+     * produces a single visible row in the UI — not 500.
+     *
+     * Resolving FallbackWriter via the container can fail at shutdown when
+     * the application is being torn down. Treat it as best-effort: if the
+     * container is gone, the error_log line from WriteFailureLogger::report
+     * is still the canonical signal.
+     */
+    private static function writeFallbackForChunk(array $originalChunk, Throwable $e): void
+    {
+        try {
+            $fallback = app(FallbackWriter::class);
+        } catch (Throwable) {
+            return;
+        }
+
+        foreach ($originalChunk as $data) {
+            $fallback->record($data, $e, 'buffer-flush');
         }
     }
 

--- a/src/Services/LogCapture.php
+++ b/src/Services/LogCapture.php
@@ -21,7 +21,8 @@ class LogCapture
 {
     public function __construct(
         protected LogWriterInterface $writer,
-        protected ContextSanitizerInterface $sanitizer
+        protected ContextSanitizerInterface $sanitizer,
+        protected FallbackWriter $fallback
     ) {}
 
     /**
@@ -73,6 +74,7 @@ class LogCapture
             return;
         }
 
+        $data = null;
         try {
             $data = $this->buildLogData($event, $channel);
             $this->writer->write($data);
@@ -83,6 +85,16 @@ class LogCapture
             // observability. WriteFailureLogger dedupes per-process so a
             // sustained outage doesn't dump thousands of identical lines.
             WriteFailureLogger::report($e, 'listener');
+
+            // Persist a minimal fallback row so the failure shows up in the
+            // LogScope UI alongside everything else, not just in error_log.
+            // If buildLogData itself threw, $data is still null — fall back
+            // to the raw MessageLogged event so we don't lose level/message.
+            if ($data !== null) {
+                $this->fallback->record($data, $e, 'listener');
+            } else {
+                $this->fallback->recordFromEvent($event, $channel, $e, 'listener');
+            }
         }
     }
 

--- a/tests/Feature/WriteFailureFallbackTest.php
+++ b/tests/Feature/WriteFailureFallbackTest.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+// Verifies that when LogScope's normal write fails (e.g. autoload corruption
+// blowing up context sanitization for a single entry), LogScope writes a
+// minimal *fallback* row to log_entries so the failure is visible in the UI
+// — not just in php-fpm's error_log.
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Context;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use LogScope\Jobs\WriteLogEntry;
+use LogScope\Logging\ChannelContextProcessor;
+use LogScope\LogScopeServiceProvider;
+use LogScope\Models\LogEntry;
+use LogScope\Services\FallbackWriter;
+use LogScope\Services\WriteFailureLogger;
+use LogScope\Services\WriteGuard;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    ChannelContextProcessor::clearLastChannel();
+    LogScopeServiceProvider::resetBufferState();
+    WriteGuard::reset();
+    WriteFailureLogger::reset();
+    FallbackWriter::reset();
+    LogEntry::query()->delete();
+
+    config(['logscope.write_mode' => 'sync']);
+    config(['logscope.write_failure.persist_fallback' => true]);
+
+    // Quiet php-fpm-style error_log emissions for the duration of the test.
+    $this->errorLogFile = tempnam(sys_get_temp_dir(), 'logscope-fallback-test-');
+    $this->originalErrorLog = ini_get('error_log');
+    ini_set('error_log', $this->errorLogFile);
+});
+
+afterEach(function () {
+    ini_set('error_log', $this->originalErrorLog);
+    if (file_exists($this->errorLogFile)) {
+        @unlink($this->errorLogFile);
+    }
+
+    LogEntry::flushEventListeners();
+
+    if (! Schema::hasTable('log_entries')) {
+        $this->artisan('migrate', ['--path' => __DIR__.'/../../database/migrations']);
+    }
+});
+
+/**
+ * Helper: poison every normal LogEntry insert. The fallback row carries a
+ * `_logscope_write_failure` marker — when the listener sees the marker, it
+ * skips throwing, so the fallback insert lands. Mirrors the production
+ * scenario where the *original* context triggers an autoload-induced
+ * fatal but a stripped-down context does not.
+ */
+function poisonNormalInserts(): void
+{
+    LogEntry::creating(function (LogEntry $entry) {
+        $context = is_array($entry->context) ? $entry->context : [];
+        if (! isset($context['_logscope_write_failure'])) {
+            throw new \Error('Class "OwenIt\\Auditing\\Models\\Audit" not found');
+        }
+    });
+}
+
+it('writes a minimal fallback row to log_entries when the sync write fails', function () {
+    poisonNormalInserts();
+
+    Log::error('original message');
+
+    $entries = LogEntry::query()->get();
+    expect($entries)->toHaveCount(1);
+
+    $entry = $entries->first();
+    expect($entry->level)->toBe('error')
+        ->and($entry->message)->toBe('original message')
+        ->and($entry->context)->toHaveKey('_logscope_write_failure');
+
+    $marker = $entry->context['_logscope_write_failure'];
+    expect($marker['exception_class'])->toBe('Error')
+        ->and($marker['exception_message'])->toContain('OwenIt\\Auditing\\Models\\Audit')
+        ->and($marker['where'])->toBe('listener');
+});
+
+it('preserves trace_id from request context on the fallback row', function () {
+    poisonNormalInserts();
+
+    Context::add('logscope', [
+        'trace_id' => 'trace-abc-123',
+        'ip_address' => '1.2.3.4',
+        'url' => 'https://example.test/foo',
+        'http_method' => 'POST',
+    ]);
+
+    Log::error('original message');
+
+    $entry = LogEntry::query()->first();
+    expect($entry)->not->toBeNull()
+        ->and($entry->trace_id)->toBe('trace-abc-123');
+});
+
+it('does not write a fallback row when persist_fallback is disabled', function () {
+    config(['logscope.write_failure.persist_fallback' => false]);
+    poisonNormalInserts();
+
+    Log::error('original message');
+
+    expect(LogEntry::query()->count())->toBe(0);
+});
+
+it('writes only one fallback row per unique failure within a single process', function () {
+    poisonNormalInserts();
+
+    for ($i = 0; $i < 25; $i++) {
+        Log::error("repeated message {$i}");
+    }
+
+    // Dedupe key is exception class + throw site. All 25 throws hit the same
+    // closure (same file/line), so the fallback writer should emit exactly one
+    // row — matching the existing WriteFailureLogger dedupe semantics.
+    expect(LogEntry::query()->count())->toBe(1);
+});
+
+it('writes a fallback row when the queue worker insert fails', function () {
+    config(['logscope.write_mode' => 'queue']);
+    Queue::fake();
+
+    Log::error('queued message');
+
+    // Capture the dispatched job, run it manually with a poisoned LogEntry.
+    Queue::assertPushed(WriteLogEntry::class, function (WriteLogEntry $job) {
+        poisonNormalInserts();
+        $job->handle();
+
+        return true;
+    });
+
+    $entries = LogEntry::query()->get();
+    expect($entries)->toHaveCount(1);
+
+    $entry = $entries->first();
+    expect($entry->message)->toBe('queued message')
+        ->and($entry->context)->toHaveKey('_logscope_write_failure');
+
+    $marker = $entry->context['_logscope_write_failure'];
+    expect($marker['where'])->toBe('queue-worker');
+});
+
+it('writes a fallback row when batch buffer flush fails', function () {
+    config(['logscope.write_mode' => 'batch']);
+
+    // Drop the table to force LogEntry::insert() to throw in performFlush.
+    // The fallback path will re-create the table for itself? No — the
+    // fallback uses the same table, so we must re-create it before the
+    // fallback runs. To exercise the wiring without needing two tables,
+    // we instead intercept via a spy on FallbackWriter and verify the call.
+    $spy = new class extends FallbackWriter
+    {
+        public array $calls = [];
+
+        public function record(array $data, \Throwable $e, string $where): void
+        {
+            $this->calls[] = ['data' => $data, 'exception_class' => get_class($e), 'where' => $where];
+        }
+    };
+    app()->instance(FallbackWriter::class, $spy);
+
+    Log::error('batched message');
+
+    Schema::drop('log_entries');
+    LogScopeServiceProvider::flushLogBufferStatic();
+
+    expect($spy->calls)->not->toBeEmpty();
+    $call = $spy->calls[0];
+    expect($call['where'])->toBe('buffer-flush')
+        ->and($call['data']['message'])->toBe('batched message');
+});
+
+it('marks the fallback row with a recognizable channel so operators can filter', function () {
+    poisonNormalInserts();
+
+    Log::channel('stack')->error('channel-tagged message');
+
+    $entry = LogEntry::query()->first();
+    expect($entry)->not->toBeNull();
+    // Original channel is preserved; the discriminator lives in context.
+    expect($entry->context)->toHaveKey('_logscope_write_failure');
+});
+
+it('reads request context from Laravel Context when recordFromEvent is called', function () {
+    // Direct unit test of the recordFromEvent path — the case where
+    // buildLogData itself threw, so we have no sanitized $data yet.
+    // Without re-reading Context here, trace_id/ip/url would be lost
+    // on the very entries operators most need to correlate.
+    Context::add('logscope', [
+        'trace_id' => 'trace-xyz-789',
+        'ip_address' => '5.6.7.8',
+        'url' => 'https://test.app/path',
+        'http_method' => 'POST',
+        'user_agent' => 'TestAgent/1.0',
+    ]);
+
+    $fallback = app(FallbackWriter::class);
+    $event = new \Illuminate\Log\Events\MessageLogged('error', 'pre-build failure', []);
+    $fallback->recordFromEvent($event, 'mychan', new \Error('Class X not found'), 'listener');
+
+    $entry = LogEntry::query()->first();
+    expect($entry)->not->toBeNull()
+        ->and($entry->trace_id)->toBe('trace-xyz-789')
+        ->and($entry->ip_address)->toBe('5.6.7.8')
+        ->and($entry->url)->toBe('https://test.app/path')
+        ->and($entry->http_method)->toBe('POST')
+        ->and($entry->user_agent)->toBe('TestAgent/1.0')
+        ->and($entry->channel)->toBe('mychan')
+        ->and($entry->message)->toBe('pre-build failure');
+});
+
+it('writes a separate fallback row for each unique throw site', function () {
+    // Dedupe key is `class@file:line`. Two distinct sites must each emit
+    // — otherwise a second, unrelated failure in the same process would
+    // be invisible.
+    $fallback = app(FallbackWriter::class);
+
+    $fallback->record(['level' => 'error', 'message' => 'one'], new \RuntimeException('a'), 'listener');
+    $fallback->record(['level' => 'error', 'message' => 'two'], new \LogicException('b'), 'listener');
+
+    expect(LogEntry::query()->count())->toBe(2);
+});
+
+it('emits a heartbeat fallback row every 100th occurrence of the same failure', function () {
+    // Strict once-per-process dedupe would let a sustained outage go
+    // silent in the UI after the first row. The 100-occurrence
+    // heartbeat (mirroring WriteFailureLogger) gives the operator
+    // a "still happening" signal without flooding the table.
+    poisonNormalInserts();
+
+    for ($i = 0; $i < 100; $i++) {
+        Log::error("attempt {$i}");
+    }
+
+    expect(LogEntry::query()->count())->toBe(2);
+
+    $occurrences = LogEntry::query()
+        ->get()
+        ->pluck('context')
+        ->map(fn ($c) => $c['_logscope_write_failure']['occurrence'])
+        ->all();
+
+    expect($occurrences)->toEqualCanonicalizing([1, 100]);
+});
+
+it('re-throws transient QueryException so Laravel retries the queue job', function () {
+    // SQLSTATE 08* (connection failures) and 40* (deadlocks) are exactly
+    // what queue retries exist for. Swallowing them — as the original
+    // catch-all did — defeats the queue's transient-error contract.
+    $job = new WriteLogEntry(['level' => 'error', 'message' => 'transient']);
+
+    $pdo = new class extends \PDOException
+    {
+        public function __construct()
+        {
+            parent::__construct('Connection lost');
+            $this->code = '08006';
+        }
+    };
+    $transient = new \Illuminate\Database\QueryException('sqlite', 'SELECT 1', [], $pdo);
+
+    LogEntry::creating(function () use ($transient) {
+        throw $transient;
+    });
+
+    expect(fn () => $job->handle())->toThrow(\Illuminate\Database\QueryException::class);
+
+    // Critical: no fallback row was written. If the retry succeeds, we'd
+    // otherwise have a duplicate (one fallback marker + one real entry).
+    expect(LogEntry::query()->count())->toBe(0);
+});
+
+it('swallows persistent failures in the queue worker and writes a fallback row', function () {
+    // Persistent errors (autoload, schema mismatch, malformed data) won't
+    // succeed on retry — they'd just loop the worker. Record observability
+    // and swallow so the job marks complete.
+    $job = new WriteLogEntry(['level' => 'error', 'message' => 'persistent']);
+
+    poisonNormalInserts();
+
+    expect(fn () => $job->handle())->not->toThrow(\Throwable::class);
+    expect(LogEntry::query()->count())->toBe(1);
+});
+
+it('survives a missing or broken FallbackWriter binding during batch flush', function () {
+    // At PHP shutdown the container can be torn down; resolving the
+    // FallbackWriter via app() may itself throw. The buffer-flush path
+    // must treat that as best-effort and not propagate the error,
+    // because we're already inside another error-handler frame.
+    config(['logscope.write_mode' => 'batch']);
+
+    app()->bind(FallbackWriter::class, function () {
+        throw new \Exception('intentionally broken container resolution');
+    });
+
+    Log::error('batched');
+
+    Schema::drop('log_entries');
+
+    expect(fn () => LogScopeServiceProvider::flushLogBufferStatic())
+        ->not->toThrow(\Throwable::class);
+});
+
+it('reset() clears the occurrence map so dedupe restarts (Octane request-boundary contract)', function () {
+    // The Octane RequestReceived listener calls FallbackWriter::reset() so
+    // a long-running worker doesn't strand its dedupe state across
+    // request boundaries. This test verifies the underlying invariant
+    // without requiring Octane to be installed.
+    poisonNormalInserts();
+
+    Log::error('first');
+    expect(LogEntry::count())->toBe(1);
+
+    FallbackWriter::reset();
+
+    Log::error('second');
+    expect(LogEntry::count())->toBe(2);
+});

--- a/tests/Feature/WriteFailureFallbackTest.php
+++ b/tests/Feature/WriteFailureFallbackTest.php
@@ -114,16 +114,16 @@ it('does not write a fallback row when persist_fallback is disabled', function (
     expect(LogEntry::query()->count())->toBe(0);
 });
 
-it('writes only one fallback row per unique failure within a single process', function () {
+it('emits a single fallback row within one heartbeat interval for repeated failures', function () {
     poisonNormalInserts();
 
+    // 25 occurrences is well below REEMIT_EVERY = 100, so we should see
+    // exactly one row — the first-occurrence emit. Heartbeat semantics are
+    // verified by the dedicated 100-occurrence test below.
     for ($i = 0; $i < 25; $i++) {
         Log::error("repeated message {$i}");
     }
 
-    // Dedupe key is exception class + throw site. All 25 throws hit the same
-    // closure (same file/line), so the fallback writer should emit exactly one
-    // row — matching the existing WriteFailureLogger dedupe semantics.
     expect(LogEntry::query()->count())->toBe(1);
 });
 
@@ -155,11 +155,10 @@ it('writes a fallback row when the queue worker insert fails', function () {
 it('writes a fallback row when batch buffer flush fails', function () {
     config(['logscope.write_mode' => 'batch']);
 
-    // Drop the table to force LogEntry::insert() to throw in performFlush.
-    // The fallback path will re-create the table for itself? No — the
-    // fallback uses the same table, so we must re-create it before the
-    // fallback runs. To exercise the wiring without needing two tables,
-    // we instead intercept via a spy on FallbackWriter and verify the call.
+    // LogEntry::insert() (the bulk-insert path) bypasses model events, so
+    // the `LogEntry::creating` poison used by sync/queue tests can't catch
+    // it. Spy on FallbackWriter instead and verify the wiring — the
+    // payload shape is already covered end-to-end by the sync tests.
     $spy = new class extends FallbackWriter
     {
         public array $calls = [];


### PR DESCRIPTION
## Summary

- When LogScope's normal write path throws (e.g. context sanitization touches a class the autoloader can't resolve, or a bulk insert blows up mid-flush), the original entry was lost from the UI — observability lived only in php-fpm's `error_log` and the cache banner.
- New `FallbackWriter` emits a minimal marker row to `log_entries` preserving the original `level`/`message`/`channel`/`trace_id`/`ip`/`url`/`user_agent`/`http_method`, with `context` replaced by `_logscope_write_failure` (exception class, truncated message, call-site label, occurrence counter).
- Wired into all three write modes: sync via `LogCapture`, queue via `WriteLogEntry::handle`, batch via `LogBuffer::performFlush`.
- Per-process counter-based dedupe with heartbeat every 100th occurrence — mirrors `WriteFailureLogger::SUMMARY_EVERY`. Octane `RequestReceived` listener resets the map so long-running workers don't strand dedupe state across requests.
- Queue retry semantics now classified: SQLSTATE `08*` (connection) and `40*` (deadlock/serialization) re-throw for Laravel retry; everything else is treated as persistent and swallowed after recording. Previously every failure looped the worker on bugs retries couldn't fix.
- Gated by `logscope.write_failure.persist_fallback` (default `true`, env `LOGSCOPE_WRITE_FAILURE_PERSIST_FALLBACK`).

## Motivating incident

User report on oreem production:
> LogScope has had 1 write failure recently. Last error: \`[Error] Class "OwenIt\Auditing\Models\Audit" not found\`

PHP marks a class as un-loadable for the rest of the process after a structural failure (`cannot extend interface ...`). Subsequent attempts to use the same FQN get "Class not found". When that happened mid-write, LogScope lost the entry entirely. This PR makes the failure visible in the UI instead.

## Test plan

- [x] `tests/Feature/WriteFailureFallbackTest.php` — 14 tests covering:
  - sync-mode fallback row written with correct shape
  - `trace_id` preserved via both `record()` and `recordFromEvent()` paths
  - config-off behavior (no row)
  - dedupe per failure-key
  - heartbeat row every 100th occurrence with correct `occurrence` counter
  - queue worker re-throws transient `QueryException` (SQLSTATE `08006`)
  - queue worker swallows persistent failure + writes fallback
  - batch flush fallback wiring (subclass-spy)
  - missing/broken `FallbackWriter` binding doesn't propagate during flush
  - `reset()` clears dedupe (Octane request-boundary contract)
  - channel preserved on the row
- [x] Full suite: 221 passed, 2 skipped, 0 failures (was 214)
- [x] `vendor/bin/pint --dirty` clean
- [x] No regressions in `WriteFailureObservabilityTest`, `ReentrantWriteGuardTest`, `LogBufferTest`

## Behavior change to call out

`WriteLogEntry::handle` previously surfaced every failure as a job-level exception. Apps relying on Laravel's queue retry for autoload/schema bugs (where retry can't help) would have looped indefinitely; that's now ended. Apps relying on retry for transient DB errors still get it — `QueryException` with SQLSTATE class `08*` or `40*` re-throws. Documented in CHANGELOG under \`### Changed\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)