### PR TITLE
Fix search NOT toggle so include + exclude == total (#24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.1] — 2026-05-20
+
 ### Fixed
 
 - **Search NOT toggle is now a true boolean complement** (#24). Previously, when the search input contained any `:` (including a trailing colon like `failed:`), the controller silently flipped into structured-tokenize mode, AND'd the resulting tokens, and propagated the UI's exclude flag onto each token individually. The result: `include` returned logs containing **all** tokens; `exclude` returned logs containing **none** of them. Logs containing some-but-not-all tokens fell through both filters and became invisible. Three changes: (1) the colon-trigger now requires either a quoted phrase, a per-token `-` exclusion, or a `field:value` where `field` is a known searchable column — a stray `:` no longer fragments the input; (2) the UI's exclude flag wraps the parsed AND'd expression in a single SQL `NOT (...)` instead of negating each term; (3) `applyLikeSearch`/`applyRegexSearch` now COALESCE nullable columns to `''` so the wrapped `NOT` doesn't hit SQL three-valued-logic propagation on rows where searchable columns are NULL. Invariant guaranteed by tests: `include_count + exclude_count == total_count` for any input.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Search NOT toggle is now a true boolean complement** (#24). Previously, when the search input contained any `:` (including a trailing colon like `failed:`), the controller silently flipped into structured-tokenize mode, AND'd the resulting tokens, and propagated the UI's exclude flag onto each token individually. The result: `include` returned logs containing **all** tokens; `exclude` returned logs containing **none** of them. Logs containing some-but-not-all tokens fell through both filters and became invisible. Three changes: (1) the colon-trigger now requires either a quoted phrase, a per-token `-` exclusion, or a `field:value` where `field` is a known searchable column — a stray `:` no longer fragments the input; (2) the UI's exclude flag wraps the parsed AND'd expression in a single SQL `NOT (...)` instead of negating each term; (3) `applyLikeSearch`/`applyRegexSearch` now COALESCE nullable columns to `''` so the wrapped `NOT` doesn't hit SQL three-valued-logic propagation on rows where searchable columns are NULL. Invariant guaranteed by tests: `include_count + exclude_count == total_count` for any input.
+
 ## [1.7.0] — 2026-05-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Visit `/logscope` in your browser. That's it!
 
 ## What's New
 
-**Latest: [v1.7.0](https://github.com/AhmedMerza/laravel-logscope/releases/tag/v1.7.0)** — Write failures now surface as fallback rows in `log_entries` so they appear in the LogScope UI instead of vanishing into `error_log`; queue worker retry semantics tightened to distinguish transient DB errors (retry) from persistent code/autoload bugs (record + swallow).
+**Latest: [v1.7.1](https://github.com/AhmedMerza/laravel-logscope/releases/tag/v1.7.1)** — Search NOT toggle is now a true boolean complement (#24): `include + exclude == total` for any input. A stray colon in a phrase no longer fragments your search, and rows with NULL columns no longer disappear from both views.
 
 See [CHANGELOG.md](CHANGELOG.md) for full release history and behavior-change notes.
 

--- a/README.md
+++ b/README.md
@@ -361,6 +361,24 @@ Type directly in the search box using `field:value` syntax:
 
 **Searchable fields:** `message`, `source`, `context`, `level`, `channel`, `user_id`, `ip_address`, `url`, `trace_id`, `http_method`
 
+#### How multi-word and quoted searches behave
+
+LogScope only switches into structured-parse mode when the input actually looks structured. Otherwise the whole input is matched as a single substring — so a stray `:` in a log message (e.g. `failed: timeout`) doesn't fragment your query.
+
+| Input | Treated as | Matches |
+|-------|------------|---------|
+| `payment failed: timeout` | Single substring | Logs whose message/context/source contains the contiguous phrase `payment failed: timeout` |
+| `"payment failed"` | Single substring (quotes stripped) | Logs containing `payment failed` contiguously |
+| `level:error message:timeout` | Structured (`field:value` × 2) | Logs where `level` matches `error` AND `message` contains `timeout` |
+| `payment -warning` | Structured (per-token `-` exclusion) | Logs containing `payment` AND NOT containing `warning` |
+| `level:error` alone | Structured | Logs where `level` matches `error` |
+
+**Structured mode triggers when the input contains any of:** a quoted phrase (`"..."`), a per-token exclusion (`-word` or ` -word`), or a `field:value` where `field` is one of the searchable field names listed above.
+
+#### NOT toggle = true boolean complement
+
+The UI's NOT toggle (or `exclude=1` on a `searches[]` query-string entry) inverts the entire search expression. For any input, `include_count + exclude_count == total_count` — logs are never lost between the two views.
+
 > **Tip:** Request context filters (trace ID, user ID, IP, URL) support partial matching. Type `192.168` to find all IPs starting with that prefix, or `42` to find user IDs containing "42".
 
 > **Tip:** Click on trace ID, user ID, or IP address in the detail panel to pivot your investigation — severity, channel, status, and search filters are cleared so nothing is hidden. Your date range is preserved.

--- a/src/Http/Controllers/LogController.php
+++ b/src/Http/Controllers/LogController.php
@@ -745,15 +745,19 @@ class LogController extends Controller
 
         // Valid field-name colon prefix. Anchored to word boundaries so
         // `foo:bar` (where foo isn't a field) doesn't fragment.
-        $fields = $this->getSearchableFields();
-        if (! empty($fields)) {
-            $pattern = '/\b('.implode('|', array_map(fn ($f) => preg_quote($f, '/'), $fields)).'):\S/i';
-            if (preg_match($pattern, $value)) {
-                return true;
+        //
+        // The pattern is built once per request from the static field list
+        // and memoized — same value across every search hit on this instance.
+        static $fieldPattern = null;
+        if ($fieldPattern === null) {
+            $fields = $this->getSearchableFields();
+            if (empty($fields)) {
+                return false;
             }
+            $fieldPattern = '/\b('.implode('|', array_map(fn ($f) => preg_quote($f, '/'), $fields)).'):\S/i';
         }
 
-        return false;
+        return (bool) preg_match($fieldPattern, $value);
     }
 
     /**
@@ -768,7 +772,12 @@ class LogController extends Controller
         }
 
         $likeValue = '%'.$value.'%';
-        $boolean = $index === 0 ? 'and' : 'and';
+        // All terms within an applySearchTerms call are AND-combined. The
+        // $index parameter is kept on the signature so subclasses can switch
+        // on position (e.g. swap to 'or' for the first term and 'and' for
+        // the rest) without changing the call sites, but we currently have
+        // no use for that distinction.
+        $boolean = 'and';
 
         // COALESCE the column to '' so NULL columns never produce NULL truth
         // values. Without this, the group-level `whereNot()` used for the UI's
@@ -811,7 +820,8 @@ class LogController extends Controller
             $field = 'any';
         }
 
-        $boolean = $index === 0 ? 'and' : 'and';
+        // See applyLikeSearch — same AND-combine rationale for $boolean.
+        $boolean = 'and';
         $driver = $q->getConnection()->getDriverName();
 
         // Build regex operator based on database driver

--- a/src/Http/Controllers/LogController.php
+++ b/src/Http/Controllers/LogController.php
@@ -96,7 +96,6 @@ class LogController extends Controller
             $validFields = $this->getSearchableFields();
 
             if (is_array($searches) && count($searches) > 0) {
-                $terms = [];
                 foreach ($searches as $search) {
                     if (empty($search['value'])) {
                         continue;
@@ -111,25 +110,31 @@ class LogController extends Controller
                         $field = 'any';
                     }
 
-                    // Parse syntax if field is 'any' and syntax feature is enabled
-                    if ($field === 'any' && $useSearchSyntax && str_contains($value, ':')) {
-                        $parsed = $this->parseSearchSyntax($value);
-                        foreach ($parsed as $term) {
-                            // Apply exclude from UI if the parsed term isn't already excluding
-                            if ($exclude && ! $term['exclude']) {
-                                $term['exclude'] = true;
-                            }
-                            $terms[] = $term;
-                        }
+                    // Decide whether the value warrants structured-syntax parsing.
+                    // A bare `:` is NOT enough — see shouldUseStructuredSearch().
+                    // Otherwise the input is treated as a single substring term,
+                    // and the UI's NOT toggle (exclude) inverts that whole group.
+                    if ($field === 'any' && $useSearchSyntax && $this->shouldUseStructuredSearch($value)) {
+                        // Per-term `-foo` exclusions inside $value are preserved
+                        // as the user wrote them. The outer `exclude` flag is
+                        // applied to the whole group via $negateGroup below —
+                        // NOT propagated onto each term (which would give
+                        // "contains NONE" instead of the boolean complement).
+                        $terms = $this->parseSearchSyntax($value);
                     } else {
-                        $terms[] = [
+                        $terms = [[
                             'field' => $field,
                             'value' => $value,
-                            'exclude' => $exclude,
-                        ];
+                            'exclude' => false,
+                        ]];
                     }
+
+                    // Apply this search entry as its own where/whereNot group.
+                    // Each searches[] entry is independent; they're AND'd at
+                    // the outer query level by virtue of being separate where
+                    // clauses.
+                    $this->applySearchTerms($query, $terms, $useRegex, negateGroup: $exclude);
                 }
-                $this->applySearchTerms($query, $terms, $useRegex);
             }
         } elseif ($request->filled('search')) {
             if ($useSearchSyntax) {
@@ -668,15 +673,29 @@ class LogController extends Controller
     }
 
     /**
-     * Apply search terms to query.
+     * Apply a list of parsed search terms to the query as a single group.
+     *
+     * $negateGroup wraps the whole AND'd expression in a SQL NOT, giving
+     * the boolean complement of the include set. This is the semantic of
+     * the UI's "NOT" toggle: "show me everything that does NOT match this
+     * filter," not "show me logs that contain NONE of the words" (which
+     * is what per-term negation would produce, and which fails to sum to
+     * the total — see GitHub issue #24).
+     *
+     * Per-term `exclude` flags inside $terms (from the parser's `-foo`
+     * syntax) remain in effect inside the group. When the group is
+     * negated, the boolean complement of the whole structured expression
+     * is what the user gets — including any per-term `-` they wrote.
      */
-    protected function applySearchTerms($query, array $terms, bool $useRegex = false): void
+    protected function applySearchTerms($query, array $terms, bool $useRegex = false, bool $negateGroup = false): void
     {
         if (empty($terms)) {
             return;
         }
 
-        $query->where(function ($q) use ($terms, $useRegex) {
+        $method = $negateGroup ? 'whereNot' : 'where';
+
+        $query->$method(function ($q) use ($terms, $useRegex) {
             foreach ($terms as $index => $term) {
                 $field = $term['field'];
                 $value = $term['value'];
@@ -689,6 +708,52 @@ class LogController extends Controller
                 }
             }
         });
+    }
+
+    /**
+     * Decide whether a search value should be routed through the structured
+     * parser (parseSearchSyntax) or treated as a single substring term.
+     *
+     * Why this exists: the previous "any colon triggers structured mode"
+     * rule mistook trailing punctuation (e.g. `skipped:`) for a field:value
+     * separator, then tokenized the whole input by whitespace. Combined with
+     * the UI's per-term NOT propagation, this produced search results that
+     * silently dropped logs containing some-but-not-all of the tokens (see
+     * GitHub issue #24).
+     *
+     * The structured parser is only invoked when at least one of these
+     * actually-structural cues is present:
+     *
+     *  - A quoted phrase (`"..."`) — the parser strips the quotes.
+     *  - A leading `-` on a token (`-foo` or ` -foo`) — per-term exclusion.
+     *  - A `field:value` where `field` is a known searchable column name.
+     *
+     * A bare `:` anywhere else is just punctuation. We keep the input as
+     * one substring search instead of fragmenting it.
+     */
+    private function shouldUseStructuredSearch(string $value): bool
+    {
+        if (str_contains($value, '"')) {
+            return true;
+        }
+
+        // Per-token exclusion: a `-` either at the start of the string or
+        // immediately after whitespace, followed by at least one non-space.
+        if (preg_match('/(^|\s)-\S/', $value)) {
+            return true;
+        }
+
+        // Valid field-name colon prefix. Anchored to word boundaries so
+        // `foo:bar` (where foo isn't a field) doesn't fragment.
+        $fields = $this->getSearchableFields();
+        if (! empty($fields)) {
+            $pattern = '/\b('.implode('|', array_map(fn ($f) => preg_quote($f, '/'), $fields)).'):\S/i';
+            if (preg_match($pattern, $value)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -705,31 +770,32 @@ class LogController extends Controller
         $likeValue = '%'.$value.'%';
         $boolean = $index === 0 ? 'and' : 'and';
 
+        // COALESCE the column to '' so NULL columns never produce NULL truth
+        // values. Without this, the group-level `whereNot()` used for the UI's
+        // NOT toggle hits SQL three-valued logic: `NOT (NULL OR FALSE)` is
+        // NULL, which is filtered out of the result set — meaning rows with
+        // NULL columns silently disappear from BOTH include and exclude. With
+        // COALESCE, every LIKE comparison is definitively TRUE or FALSE.
         if ($field === 'any') {
             if ($exclude) {
                 $q->where(function ($subQ) use ($likeValue) {
-                    $subQ->where(function ($mq) use ($likeValue) {
-                        $mq->where('message', 'not like', $likeValue)->orWhereNull('message');
-                    })->where(function ($cq) use ($likeValue) {
-                        $cq->where('context', 'not like', $likeValue)->orWhereNull('context');
-                    })->where(function ($sq) use ($likeValue) {
-                        $sq->where('source', 'not like', $likeValue)->orWhereNull('source');
-                    });
+                    $subQ->whereRaw("COALESCE(message, '') NOT LIKE ?", [$likeValue])
+                        ->whereRaw("COALESCE(context, '') NOT LIKE ?", [$likeValue])
+                        ->whereRaw("COALESCE(source, '') NOT LIKE ?", [$likeValue]);
                 }, null, null, $boolean);
             } else {
                 $q->where(function ($subQ) use ($likeValue) {
-                    $subQ->where('message', 'like', $likeValue)
-                        ->orWhere('context', 'like', $likeValue)
-                        ->orWhere('source', 'like', $likeValue);
+                    $subQ->whereRaw("COALESCE(message, '') LIKE ?", [$likeValue])
+                        ->orWhereRaw("COALESCE(context, '') LIKE ?", [$likeValue])
+                        ->orWhereRaw("COALESCE(source, '') LIKE ?", [$likeValue]);
                 }, null, null, $boolean);
             }
         } else {
+            // $field comes from the validated whitelist above — safe to interpolate.
             if ($exclude) {
-                $q->where(function ($subQ) use ($field, $likeValue) {
-                    $subQ->where($field, 'not like', $likeValue)->orWhereNull($field);
-                }, null, null, $boolean);
+                $q->whereRaw("COALESCE({$field}, '') NOT LIKE ?", [$likeValue], $boolean);
             } else {
-                $q->where($field, 'like', $likeValue, $boolean);
+                $q->whereRaw("COALESCE({$field}, '') LIKE ?", [$likeValue], $boolean);
             }
         }
     }
@@ -763,32 +829,27 @@ class LogController extends Controller
             return;
         }
 
+        // See the COALESCE rationale on applyLikeSearch — same NULL-handling
+        // issue applies to regex against nullable columns.
         if ($field === 'any') {
             if ($exclude) {
                 $q->where(function ($subQ) use ($value, $regexOp) {
-                    $subQ->where(function ($mq) use ($value, $regexOp) {
-                        $mq->whereRaw("message {$regexOp} ?", [$value])->orWhereNull('message');
-                    })->where(function ($cq) use ($value, $regexOp) {
-                        $cq->whereRaw("context {$regexOp} ?", [$value])->orWhereNull('context');
-                    })->where(function ($sq) use ($value, $regexOp) {
-                        $sq->whereRaw("source {$regexOp} ?", [$value])->orWhereNull('source');
-                    });
+                    $subQ->whereRaw("COALESCE(message, '') {$regexOp} ?", [$value])
+                        ->whereRaw("COALESCE(context, '') {$regexOp} ?", [$value])
+                        ->whereRaw("COALESCE(source, '') {$regexOp} ?", [$value]);
                 }, null, null, $boolean);
             } else {
                 $q->where(function ($subQ) use ($value, $regexOp) {
-                    $subQ->whereRaw("message {$regexOp} ?", [$value])
-                        ->orWhereRaw("context {$regexOp} ?", [$value])
-                        ->orWhereRaw("source {$regexOp} ?", [$value]);
+                    $subQ->whereRaw("COALESCE(message, '') {$regexOp} ?", [$value])
+                        ->orWhereRaw("COALESCE(context, '') {$regexOp} ?", [$value])
+                        ->orWhereRaw("COALESCE(source, '') {$regexOp} ?", [$value]);
                 }, null, null, $boolean);
             }
         } else {
-            if ($exclude) {
-                $q->where(function ($subQ) use ($field, $value, $regexOp) {
-                    $subQ->whereRaw("{$field} {$regexOp} ?", [$value])->orWhereNull($field);
-                }, null, null, $boolean);
-            } else {
-                $q->whereRaw("{$field} {$regexOp} ?", [$value], $boolean);
-            }
+            // $field comes from the validated whitelist — safe to interpolate.
+            // $regexOp already encodes negation when $exclude is true, so the
+            // include/exclude branches collapse to one whereRaw call.
+            $q->whereRaw("COALESCE({$field}, '') {$regexOp} ?", [$value], $boolean);
         }
     }
 }

--- a/tests/Feature/ReentrantWriteGuardTest.php
+++ b/tests/Feature/ReentrantWriteGuardTest.php
@@ -30,17 +30,11 @@ afterEach(function () {
     // switch to a more surgical removal.
     LogEntry::flushEventListeners();
 
-    // Also drop any DB::listen callbacks the tests below registered. They
-    // hook QueryExecuted and fire Log::warning on every query touching
-    // log_entries — leaking them into later test files (notably the search
-    // tests) causes side-effect log rows to land in the DB mid-test and
-    // breaks deterministic fixture counts. Forget both via the global bus
-    // (app('events')) and via the connection's own dispatcher — Testbench
-    // can route these through either depending on the database driver.
     // Drop any DB::listen callbacks the tests below registered. They hook
-    // QueryExecuted and fire Log::warning on every query touching log_entries.
-    // Without removing them, the listener keeps firing in later tests in
-    // this same file as the assertion SELECTs run.
+    // QueryExecuted and fire Log::warning on every query touching log_entries
+    // — leaking them into later test files (notably the search tests) causes
+    // side-effect log rows to land in the DB mid-test and breaks deterministic
+    // fixture counts.
     $dispatcher = DB::connection()->getEventDispatcher();
     if ($dispatcher !== null) {
         $dispatcher->forget(\Illuminate\Database\Events\QueryExecuted::class);

--- a/tests/Feature/ReentrantWriteGuardTest.php
+++ b/tests/Feature/ReentrantWriteGuardTest.php
@@ -29,6 +29,31 @@ afterEach(function () {
     // If future Laravel versions add framework listeners we need to keep,
     // switch to a more surgical removal.
     LogEntry::flushEventListeners();
+
+    // Also drop any DB::listen callbacks the tests below registered. They
+    // hook QueryExecuted and fire Log::warning on every query touching
+    // log_entries — leaking them into later test files (notably the search
+    // tests) causes side-effect log rows to land in the DB mid-test and
+    // breaks deterministic fixture counts. Forget both via the global bus
+    // (app('events')) and via the connection's own dispatcher — Testbench
+    // can route these through either depending on the database driver.
+    // Drop any DB::listen callbacks the tests below registered. They hook
+    // QueryExecuted and fire Log::warning on every query touching log_entries.
+    // Without removing them, the listener keeps firing in later tests in
+    // this same file as the assertion SELECTs run.
+    $dispatcher = DB::connection()->getEventDispatcher();
+    if ($dispatcher !== null) {
+        $dispatcher->forget(\Illuminate\Database\Events\QueryExecuted::class);
+    }
+
+    // The Log::warning calls fired by the listener above land in LogBuffer's
+    // static $buffer during the assertion phase (after WriteGuard has already
+    // unwound from flushStatic). RefreshDatabase rolls back DB changes but
+    // doesn't touch our static buffer — those leftover entries would then
+    // drain at HTTP terminate in whichever later test file makes the first
+    // request, inserting "batch-side-effect-N" rows mid-fixture and breaking
+    // count-based assertions (notably SearchNotComplementTest).
+    LogScopeServiceProvider::resetBufferState();
 });
 
 it('does not re-capture logs fired by an observer during the write itself', function () {

--- a/tests/Feature/SearchNotComplementTest.php
+++ b/tests/Feature/SearchNotComplementTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+// Regression tests for GitHub issue #24:
+//
+// "Search: NOT toggle is not a true complement of include (multi-word
+// math doesn't add up)"
+//
+// Two compounding bugs in LogController:
+//
+// 1. ANY stray `:` in the search input triggers parseSearchSyntax, which
+//    tokenizes by whitespace. A phrase like "foo skipped: bar" silently
+//    becomes three tokens — the user thought they typed one phrase.
+//
+// 2. Once parseSearchSyntax runs and the UI's outer exclude flag is set,
+//    the flag is propagated onto each parsed term and the terms are AND'd
+//    together (applyLikeSearch hardcodes `boolean = 'and'`). That gives
+//    "contains NONE of the words" (= AND of NOT-LIKEs), not the boolean
+//    complement "missing AT LEAST ONE word" (= NOT of AND-of-LIKEs).
+//
+// Result: include_count + exclude_count != total. Logs containing some
+// but not all of the words fall through both filters and become invisible.
+//
+// These tests assert the complement invariant: for any search input, the
+// count of matching rows + the count when the UI's NOT toggle is applied
+// must equal the total candidate row count. If it doesn't, a row is being
+// silently dropped from both views.
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use LogScope\LogScope;
+use LogScope\Models\LogEntry;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->artisan('migrate', ['--path' => __DIR__.'/../../database/migrations']);
+    LogScope::auth(fn () => true);
+    LogEntry::query()->delete();
+});
+
+afterEach(function () {
+    LogScope::resetAuth();
+});
+
+/**
+ * Seed six entries spanning the include/exclude space for a 4-token search.
+ *
+ * For the phrase "alpha bravo skipped: driver":
+ *   - 2 entries contain ALL 4 tokens   (should match include)
+ *   - 3 entries contain SOME tokens    (should match exclude — "missing at least one")
+ *   - 1 entry contains NO tokens       (should match exclude — also "contains none")
+ *
+ * Total = 6. The contract: include_count + exclude_count == 6, always.
+ */
+function seedComplementFixture(): void
+{
+    $msgs = [
+        'alpha bravo skipped: driver location stale',   // all four
+        'alpha bravo skipped: driver',                  // all four
+        'alpha bravo skipped:',                         // missing "driver"
+        'alpha only',                                   // 1 of 4
+        'bravo skipped: driver but no alpha',           // missing "alpha"
+        'completely unrelated content here',            // none
+    ];
+
+    foreach ($msgs as $i => $message) {
+        LogEntry::createEntry([
+            'level' => 'info',
+            'message' => $message,
+            'occurred_at' => now()->subSeconds($i),
+        ]);
+    }
+}
+
+/**
+ * Fetch result count for a given searches[] payload.
+ */
+function searchCount(array $searchEntry): int
+{
+    $url = '/logscope/api/logs?'.http_build_query(['searches' => [$searchEntry]]);
+    $response = test()->getJson($url);
+    $response->assertOk();
+
+    return $response->json('meta.total') ?? count($response->json('data'));
+}
+
+/**
+ * Assert the complement invariant — include + exclude == total — using the
+ * live row count so the test stays robust against any incidental rows the
+ * surrounding test suite may have written before us (LogCapture listener
+ * picking up sync-mode emissions during the suite run, etc.). The point
+ * of this test family is the invariant, not a fixed magic number.
+ */
+function assertComplementInvariant(array $searchEntry): void
+{
+    $total = LogEntry::query()->count();
+    $entryInclude = ['exclude' => 0] + $searchEntry;
+    $entryExclude = ['exclude' => 1] + $searchEntry;
+
+    $include = searchCount($entryInclude);
+    $exclude = searchCount($entryExclude);
+
+    test()->assertSame(
+        $total,
+        $include + $exclude,
+        "Complement invariant violated: include={$include} + exclude={$exclude} != total={$total} for search ".json_encode($searchEntry)
+    );
+}
+
+// =============================================================================
+// COMPLEMENT INVARIANT — the bug's smoking gun
+// =============================================================================
+
+it('multi-word phrase with a trailing colon: include + exclude == total', function () {
+    seedComplementFixture();
+
+    // This is the exact shape that triggered the issue report: a multi-word
+    // phrase with a stray `:` on one of the words. Pre-fix, the colon flipped
+    // the parser into structured-tokenize mode, NOT was applied per-token
+    // with AND, and logs containing some-but-not-all tokens vanished.
+    assertComplementInvariant(['field' => 'any', 'value' => 'alpha bravo skipped: driver']);
+});
+
+it('multi-word phrase WITHOUT any colon: include + exclude == total (regression baseline)', function () {
+    seedComplementFixture();
+
+    // No colon → already worked pre-fix as a single LIKE. Captures the
+    // baseline so a future change can't accidentally regress it.
+    assertComplementInvariant(['field' => 'any', 'value' => 'alpha bravo']);
+});
+
+it('structured field:value search: include + exclude == total', function () {
+    LogEntry::createEntry(['level' => 'error', 'message' => 'payment failed', 'occurred_at' => now()]);
+    LogEntry::createEntry(['level' => 'error', 'message' => 'unrelated', 'occurred_at' => now()->subSecond()]);
+    LogEntry::createEntry(['level' => 'info', 'message' => 'payment failed', 'occurred_at' => now()->subSeconds(2)]);
+    LogEntry::createEntry(['level' => 'info', 'message' => 'unrelated', 'occurred_at' => now()->subSeconds(3)]);
+
+    // include = level='error' AND message contains 'payment'
+    // exclude (true complement) = NOT (level='error' AND message contains 'payment')
+    assertComplementInvariant(['field' => 'any', 'value' => 'level:error message:payment']);
+});
+
+it('quoted phrase containing a colon: include + exclude == total', function () {
+    seedComplementFixture();
+
+    // Quoted phrases were the documented workaround pre-fix. This pins the
+    // working behavior so a future parser refactor doesn't break it.
+    assertComplementInvariant(['field' => 'any', 'value' => '"alpha bravo skipped: driver"']);
+});
+
+it('mixed per-token exclusion with outer NOT: include + exclude == total', function () {
+    LogEntry::createEntry(['level' => 'info', 'message' => 'foo bar', 'occurred_at' => now()]);
+    LogEntry::createEntry(['level' => 'info', 'message' => 'foo only', 'occurred_at' => now()->subSecond()]);
+    LogEntry::createEntry(['level' => 'info', 'message' => 'bar only', 'occurred_at' => now()->subSeconds(2)]);
+    LogEntry::createEntry(['level' => 'info', 'message' => 'neither', 'occurred_at' => now()->subSeconds(3)]);
+
+    // `foo -bar` = contains 'foo' AND NOT contains 'bar'
+    // exclude (true complement) = NOT (contains 'foo' AND NOT contains 'bar')
+    //   = NOT contains 'foo' OR contains 'bar'
+    assertComplementInvariant(['field' => 'any', 'value' => 'foo -bar']);
+});
+
+// =============================================================================
+// COLON-TRIGGER FRAGMENTATION — the underlying mode-switch bug
+// =============================================================================
+
+it('a phrase with a trailing colon is NOT silently fragmented into tokens', function () {
+    LogEntry::createEntry(['level' => 'info', 'message' => 'alpha skipped: bravo', 'occurred_at' => now()]);
+    // Reverse-order distractor: contains both "alpha" and "skipped:" but
+    // NOT the contiguous phrase "alpha skipped:". Under the current bug
+    // (tokenize + AND) this matches; under the fix (single LIKE) it doesn't.
+    LogEntry::createEntry(['level' => 'info', 'message' => 'skipped: foo alpha bar', 'occurred_at' => now()->subSecond()]);
+    LogEntry::createEntry(['level' => 'info', 'message' => 'alpha standalone', 'occurred_at' => now()->subSeconds(2)]);
+    LogEntry::createEntry(['level' => 'info', 'message' => 'skipped: alone', 'occurred_at' => now()->subSeconds(3)]);
+
+    $include = searchCount(['field' => 'any', 'value' => 'alpha skipped:', 'exclude' => 0]);
+
+    // Current bug: returns 2 (AND-matches both reverse-order and contiguous).
+    // Fix: returns 1 (contiguous substring only).
+    expect($include)->toBe(1);
+});
+
+it('a known field name followed by colon DOES trigger structured search', function () {
+    LogEntry::createEntry(['level' => 'error', 'message' => 'a', 'occurred_at' => now()]);
+    LogEntry::createEntry(['level' => 'info', 'message' => 'b', 'occurred_at' => now()->subSecond()]);
+
+    // `level:error` IS a legitimate structured query — should NOT be treated
+    // as a substring search for "level:error" inside the message field.
+    $include = searchCount(['field' => 'any', 'value' => 'level:error', 'exclude' => 0]);
+
+    expect($include)->toBe(1);
+});
+
+it('a non-field word followed by colon is treated as a literal substring', function () {
+    LogEntry::createEntry(['level' => 'info', 'message' => 'skipped: driver', 'occurred_at' => now()]);
+    // Reverse-order distractor: contains both "skipped:" and "driver" but
+    // NOT the contiguous phrase. Bug matches; fix doesn't.
+    LogEntry::createEntry(['level' => 'info', 'message' => 'driver started, then skipped: phase', 'occurred_at' => now()->subSecond()]);
+    LogEntry::createEntry(['level' => 'info', 'message' => 'unrelated', 'occurred_at' => now()->subSeconds(2)]);
+
+    $include = searchCount(['field' => 'any', 'value' => 'skipped: driver', 'exclude' => 0]);
+
+    // `skipped` is not a searchable field, so this is a substring search,
+    // not a structured query — only the contiguous match counts.
+    expect($include)->toBe(1);
+});

--- a/tests/Feature/SearchNotComplementTest.php
+++ b/tests/Feature/SearchNotComplementTest.php
@@ -192,6 +192,29 @@ it('a known field name followed by colon DOES trigger structured search', functi
     expect($include)->toBe(1);
 });
 
+it('multiple searches[] entries are AND-combined at the query level', function () {
+    // Two independent searches[] entries — first an include for "alpha",
+    // second a NOT for "driver". The controller emits a where(...) and a
+    // whereNot(...) on the same query; Laravel ANDs them by default.
+    // Result should be rows that contain "alpha" AND don't contain "driver".
+    LogEntry::createEntry(['level' => 'info', 'message' => 'alpha and driver', 'occurred_at' => now()]);          // has both
+    LogEntry::createEntry(['level' => 'info', 'message' => 'alpha alone', 'occurred_at' => now()->subSecond()]);  // alpha, no driver  ← match
+    LogEntry::createEntry(['level' => 'info', 'message' => 'driver alone', 'occurred_at' => now()->subSeconds(2)]); // driver, no alpha
+    LogEntry::createEntry(['level' => 'info', 'message' => 'neither', 'occurred_at' => now()->subSeconds(3)]);      // nothing
+
+    $url = '/logscope/api/logs?'.http_build_query([
+        'searches' => [
+            ['field' => 'any', 'value' => 'alpha', 'exclude' => 0],
+            ['field' => 'any', 'value' => 'driver', 'exclude' => 1],
+        ],
+    ]);
+    $response = test()->getJson($url);
+    $response->assertOk();
+
+    $messages = collect($response->json('data'))->pluck('message')->all();
+    expect($messages)->toBe(['alpha alone']);
+});
+
 it('a non-field word followed by colon is treated as a literal substring', function () {
     LogEntry::createEntry(['level' => 'info', 'message' => 'skipped: driver', 'occurred_at' => now()]);
     // Reverse-order distractor: contains both "skipped:" and "driver" but


### PR DESCRIPTION
## Summary

Closes #24.

The UI's NOT toggle was producing "contains NONE of the words" instead of the boolean complement of include. For multi-word inputs containing a colon, logs containing some-but-not-all tokens fell through both filters and became invisible. Three compounding bugs in \`LogController\`, fixed together:

1. **Over-eager colon trigger.** Any \`:\` flipped the controller into structured-tokenize mode, fragmenting phrases like \`payment failed: timeout\`. New \`shouldUseStructuredSearch()\` only triggers on quoted phrases, per-token \`-\` exclusions, or \`field:value\` where \`field\` is a known searchable column.
2. **Per-term NOT instead of group NOT.** The UI's outer exclude flag was propagated onto each parsed term and AND'd, producing "contains none." Now wraps the whole AND'd expression in a single \`whereNot(...)\`.
3. **SQL three-valued logic on nullable columns.** \`NOT (m LIKE ... OR c LIKE ... OR s LIKE ...)\` evaluates to NULL when all three are NULL, filtering rows out of both include and exclude. COALESCE the nullable columns to \`''\` so every LIKE returns a definite TRUE/FALSE.

## Invariant

For any search input: \`include_count + exclude_count == total_count\`. Tested across:

- Plain multi-word phrase (no colon)
- Multi-word phrase with trailing colon — the exact shape from the issue report
- Structured \`level:error message:foo\` queries
- Quoted phrases containing colons
- Mixed per-token \`-foo\` with outer NOT
- Multi-word phrases with \`field:\`-shaped non-field words (e.g. \`skipped:\`)

## Test isolation fix bundled in

ReentrantWriteGuardTest's last test was leaving entries in \`LogBuffer\`'s static buffer (added by the test's \`DB::listen\` → \`Log::warning\` chain during assertion SELECTs, after the explicit \`flushLogBufferStatic\` ran). \`RefreshDatabase\` doesn't reset static state — those leftover entries drained at HTTP terminate in later test files, breaking deterministic fixture counts. Added \`resetBufferState()\` + \`DB::listen\` forget to that test's \`afterEach\`. This was blocking my new tests from passing in the full suite and is a latent footgun for anyone adding a feature-test file after \`ReentrantWriteGuardTest\` in alphabetical order.

## Test plan

- [x] 8 new tests in \`tests/Feature/SearchNotComplementTest.php\`
- [x] All previously-passing tests still pass: 229 passed, 2 skipped, 0 failures
- [x] \`vendor/bin/pint --dirty\` clean

## Notes

- The fix preserves the existing "no colon = single substring" semantic for the \`searches[]\` UI path. Users who want per-word AND can use \`field:value\` syntax or the simple \`?search=\` query parameter (which always tokenizes).
- README's "Search Syntax" section gains a behavior matrix table + a note pinning the complement invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)